### PR TITLE
Adds a new cheat that let you transform from the start of the game.

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -173,6 +173,7 @@ struct UserSettings {
         ConfigVar<bool> fastSpinner;
         ConfigVar<bool> freeMagicArmor;
         ConfigVar<bool> invincibleEnemies;
+        ConfigVar<bool> transformWithoutShadowCrystal;
 
         // Technical
         ConfigVar<bool> restoreWiiGlitches;

--- a/src/d/actor/d_a_alink_dusk.cpp
+++ b/src/d/actor/d_a_alink_dusk.cpp
@@ -72,7 +72,7 @@ void daAlink_c::handleQuickTransform() {
     }
 
     // Check to see if Link has the ability to transform.
-    if (!dComIfGs_isEventBit(dSv_event_flag_c::M_077)) {
+    if (!dComIfGs_isEventBit(dSv_event_flag_c::M_077) and !dusk::getSettings().game.transformWithoutShadowCrystal) {
         return;
     }
 
@@ -102,7 +102,7 @@ void daAlink_c::handleQuickTransform() {
     }
 
     // Ensure that the Z Button is not dimmed
-    if (meterDrawPtr->getButtonZAlpha() != 1.f) {
+    if (meterDrawPtr->getButtonZAlpha() != 1.f and !dusk::getSettings().game.transformWithoutShadowCrystal) {
         Z2GetAudioMgr()->seStart(Z2SE_SYS_ERROR, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
         return;
     }
@@ -122,7 +122,7 @@ void daAlink_c::handleQuickTransform() {
     bool canTransform = false;
 
     if (mLinkAcch.ChkGroundHit() && !checkModeFlg(MODE_PLAYER_FLY) && !checkMagneBootsOn()) {
-        if (checkMidnaRide()) {
+        if (checkMidnaRide() or dusk::getSettings().game.transformWithoutShadowCrystal) {
             if ((checkWolf() &&
                  (checkModeFlg(MODE_UNK_1000) || dComIfGp_checkPlayerStatus0(0, 0x10))) ||
                 (!checkWolf() &&

--- a/src/d/actor/d_a_alink_dusk.cpp
+++ b/src/d/actor/d_a_alink_dusk.cpp
@@ -72,7 +72,7 @@ void daAlink_c::handleQuickTransform() {
     }
 
     // Check to see if Link has the ability to transform.
-    if (!dComIfGs_isEventBit(dSv_event_flag_c::M_077) and !dusk::getSettings().game.transformWithoutShadowCrystal) {
+    if (!dComIfGs_isEventBit(dSv_event_flag_c::M_077) && !dusk::getSettings().game.transformWithoutShadowCrystal) {
         return;
     }
 
@@ -102,7 +102,7 @@ void daAlink_c::handleQuickTransform() {
     }
 
     // Ensure that the Z Button is not dimmed
-    if (meterDrawPtr->getButtonZAlpha() != 1.f and !dusk::getSettings().game.transformWithoutShadowCrystal) {
+    if (meterDrawPtr->getButtonZAlpha() != 1.f && !dusk::getSettings().game.transformWithoutShadowCrystal) {
         Z2GetAudioMgr()->seStart(Z2SE_SYS_ERROR, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
         return;
     }
@@ -122,7 +122,7 @@ void daAlink_c::handleQuickTransform() {
     bool canTransform = false;
 
     if (mLinkAcch.ChkGroundHit() && !checkModeFlg(MODE_PLAYER_FLY) && !checkMagneBootsOn()) {
-        if (checkMidnaRide() or dusk::getSettings().game.transformWithoutShadowCrystal) {
+        if (checkMidnaRide() || dusk::getSettings().game.transformWithoutShadowCrystal) {
             if ((checkWolf() &&
                  (checkModeFlg(MODE_UNK_1000) || dComIfGp_checkPlayerStatus0(0, 0x10))) ||
                 (!checkWolf() &&

--- a/src/d/actor/d_a_midna.cpp
+++ b/src/d/actor/d_a_midna.cpp
@@ -3106,14 +3106,15 @@ void daMidna_c::setMidnaNoDrawFlg() {
 
 BOOL daMidna_c::checkMetamorphoseEnableBase() {
     BOOL tmp;
-    if (!daAlink_getAlinkActorClass()->checkMidnaRide() || (g_env_light.mEvilInitialized & 0x80) ||
-        /* dSv_event_flag_c::M_077 - Main Event - Get shadow crystal (can now transform) */
-        !dComIfGs_isEventBit(0xD04) ||
+    if (((!daAlink_getAlinkActorClass()->checkMidnaRide()  || (g_env_light.mEvilInitialized & 0x80) ||
+          /* dSv_event_flag_c::M_077 - Main Event - Get shadow crystal (can now transform) */
+          !dComIfGs_isEventBit(0xD04)) &&
+          !dusk::getSettings().game.transformWithoutShadowCrystal) ||
 #if TARGET_PC
-        (fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp) &&
-         !dusk::getSettings().game.canTransformAnywhere)
+          (fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp) &&
+           !dusk::getSettings().game.canTransformAnywhere)
 #else
-        fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp)
+          fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp)
 #endif
     )
     {

--- a/src/d/actor/d_a_midna.cpp
+++ b/src/d/actor/d_a_midna.cpp
@@ -3106,14 +3106,17 @@ void daMidna_c::setMidnaNoDrawFlg() {
 
 BOOL daMidna_c::checkMetamorphoseEnableBase() {
     BOOL tmp;
+#if TARGET_PC
     if (((!daAlink_getAlinkActorClass()->checkMidnaRide()  || (g_env_light.mEvilInitialized & 0x80) ||
           /* dSv_event_flag_c::M_077 - Main Event - Get shadow crystal (can now transform) */
           !dComIfGs_isEventBit(0xD04)) &&
           !dusk::getSettings().game.transformWithoutShadowCrystal) ||
-#if TARGET_PC
           (fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp) &&
            !dusk::getSettings().game.canTransformAnywhere)
 #else
+    if (!daAlink_getAlinkActorClass()->checkMidnaRide()  || (g_env_light.mEvilInitialized & 0x80) ||
+          /* dSv_event_flag_c::M_077 - Main Event - Get shadow crystal (can now transform) */
+          !dComIfGs_isEventBit(0xD04) || 
           fopAcIt_Judge((fopAcIt_JudgeFunc)daMidna_searchNpc, &tmp)
 #endif
     )

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -2833,7 +2833,7 @@ BOOL dComIfGs_Wolf_Change_Check() {
     BOOL is_wolf = false;
 
     // Transforming Unlocked
-    if (dComIfGs_isEventBit(0x0D04)) {
+    if (dComIfGs_isEventBit(0x0D04) or dusk::getSettings().game.transformWithoutShadowCrystal) {
         is_wolf = dComIfGs_getTransformStatus();
     } else if (dComIfGs_isTransformLV(0) && !dComIfGs_isDarkClearLV(0)) {
         is_wolf = true;

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -2833,7 +2833,11 @@ BOOL dComIfGs_Wolf_Change_Check() {
     BOOL is_wolf = false;
 
     // Transforming Unlocked
-    if (dComIfGs_isEventBit(0x0D04) || dusk::getSettings().game.transformWithoutShadowCrystal) {
+    if (dComIfGs_isEventBit(0x0D04)
+#if TARGET_PC
+    || dusk::getSettings().game.transformWithoutShadowCrystal
+#endif
+    ) {
         is_wolf = dComIfGs_getTransformStatus();
     } else if (dComIfGs_isTransformLV(0) && !dComIfGs_isDarkClearLV(0)) {
         is_wolf = true;

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -2833,7 +2833,7 @@ BOOL dComIfGs_Wolf_Change_Check() {
     BOOL is_wolf = false;
 
     // Transforming Unlocked
-    if (dComIfGs_isEventBit(0x0D04) or dusk::getSettings().game.transformWithoutShadowCrystal) {
+    if (dComIfGs_isEventBit(0x0D04) || dusk::getSettings().game.transformWithoutShadowCrystal) {
         is_wolf = dComIfGs_getTransformStatus();
     } else if (dComIfGs_isTransformLV(0) && !dComIfGs_isDarkClearLV(0)) {
         is_wolf = true;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -108,6 +108,7 @@ UserSettings g_userSettings = {
         .fastSpinner {"game.fastSpinner", false},
         .freeMagicArmor {"game.freeMagicArmor", false},
         .invincibleEnemies {"game.invincibleEnemies", false},
+        .transformWithoutShadowCrystal {"game.transformWithoutShadowCrystal", false},
 
         // Technical
         .restoreWiiGlitches {"game.restoreWiiGlitches", false},
@@ -191,6 +192,7 @@ void registerSettings() {
     // Game
     Register(g_userSettings.game.language);
     Register(g_userSettings.game.enableQuickTransform);
+    Register(g_userSettings.game.transformWithoutShadowCrystal);
     Register(g_userSettings.game.hideTvSettingsScreen);
     Register(g_userSettings.game.biggerWallets);
     Register(g_userSettings.game.noReturnRupees);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1177,6 +1177,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Lets the magic armor work without consuming rupees.");
         addCheat("Invincible Enemies", getSettings().game.invincibleEnemies,
             "Prevents enemies from taking damage.");
+        addCheat("Transform without Shadow Crystal", getSettings().game.transformWithoutShadowCrystal,
+            "Allows Link to transform without the Shadow Crystal (Only using Quick Transform.)");
     });
 
     add_tab("Interface", [this](Rml::Element* content) {


### PR DESCRIPTION
Not fully implemented - Currently does not bypass the check when entering a new zone that sets you to the correct form, unless you edit your Transform Level manually from the save editor.

Allows transformation _only_ using the R+Y quick transform feature, even before meeting Midna or obtaining the Shadow Shard. Intentionally does not alter behavior of the midna menu to avoid possibly breaking any scripted dialogue or interactions before you would normally have the option in the menu.
