### PR TITLE
Alternate Config Variable Migration Method

### DIFF
--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -58,6 +58,8 @@ template<ConfigValue T>
 void ConfigImpl<T>::loadFromJson(ConfigVar<T>& cVar, const json& jsonValue) {
     if constexpr (std::is_enum_v<T>) {
         if (jsonValue.is_boolean()) {
+            DuskConfigLog.error("Doing default migration of CVar {} from bool, enum values may not be what is expected!", cVar.getName());
+
             using Underlying = std::underlying_type_t<T>;
             const bool b = jsonValue.get<bool>();
 

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -61,12 +61,7 @@ void ConfigImpl<T>::loadFromJson(ConfigVar<T>& cVar, const json& jsonValue) {
             using Underlying = std::underlying_type_t<T>;
             const bool b = jsonValue.get<bool>();
 
-            Underlying raw;
-            if constexpr (std::is_same_v<T, dusk::FrameInterpMode>) {
-                raw = b ? static_cast<Underlying>(2) : static_cast<Underlying>(0);
-            } else {
-                raw = b ? static_cast<Underlying>(1) : static_cast<Underlying>(0);
-            }
+            const Underlying raw = b ? static_cast<Underlying>(1) : static_cast<Underlying>(0);
 
             cVar.setValue(sanitizeEnumValue(cVar, static_cast<T>(raw)), false);
             return;
@@ -175,6 +170,19 @@ namespace dusk::config {
     template class ConfigImpl<dusk::DiscVerificationState>;
     template class ConfigImpl<dusk::GameLanguage>;
     template class ConfigImpl<dusk::GyroMode>;
+
+    template<> void ConfigImpl<FrameInterpMode>::loadFromJson(ConfigVar<FrameInterpMode>& cVar, const json& jsonValue) {
+        if (jsonValue.is_boolean()) {
+            const bool b = jsonValue.get<bool>();
+
+            const FrameInterpMode mode = b ? FrameInterpMode::Unlimited : FrameInterpMode::Off;
+
+            cVar.setValue(sanitizeEnumValue(cVar, mode), false);
+            return;
+        }
+
+        cVar.setValue(sanitizeEnumValue(cVar, jsonValue.get<FrameInterpMode>()), false);
+    }
     template class ConfigImpl<dusk::FrameInterpMode>;
 }
 


### PR DESCRIPTION
This avoids hardcoding special cases into the main template, which I think is more sustainable in the long-run if we need to migrate other settings ever.

~~Might also be worth having a more explicit warning or indicator in the default case to alert you that 0/1 default values for the new enum might not match the intended enum values, though I haven't added that yet. I can work on it if it's something we want to include.~~ Also adds a non-fatal error in the config log in the case of a default bool -> enum migration.