### PR TITLE
macOS: Open data folder from menu bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,8 +579,9 @@ endif ()
 
 if (APPLE AND NOT IOS AND NOT TVOS)
     find_library(APPKIT_FRAMEWORK AppKit REQUIRED)
-    target_sources(dusklight PRIVATE src/dusk/file_select_macos.mm)
+    target_sources(dusklight PRIVATE src/dusk/file_select_macos.mm src/dusk/macos_menu.mm)
     set_source_files_properties(src/dusk/file_select_macos.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
+    set_source_files_properties(src/dusk/macos_menu.mm PROPERTIES COMPILE_FLAGS -fobjc-arc)
     target_link_libraries(dusklight PRIVATE ${APPKIT_FRAMEWORK})
 endif ()
 

--- a/src/dusk/macos_menu.hpp
+++ b/src/dusk/macos_menu.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+// Only include this header on macOS
+#if defined(__APPLE__) && !TARGET_OS_IOS && !TARGET_OS_TV && !TARGET_OS_MACCATALYST
+
+namespace dusk {
+
+// App menu actions (e.g., "Open Data Folder..." in the app name menu)
+void InstallMacOSAppMenuActions();
+
+}  // namespace dusk
+
+#endif

--- a/src/dusk/macos_menu.mm
+++ b/src/dusk/macos_menu.mm
@@ -1,0 +1,60 @@
+#include "macos_menu.hpp"
+
+#include "dusk/data.hpp"
+
+#import <AppKit/AppKit.h>
+
+@interface DuskAppMenuTarget : NSObject
+- (void)openDataFolder:(id)sender;
+@end
+
+@implementation DuskAppMenuTarget
+- (void)openDataFolder:(id)sender {
+  (void)sender;
+  dusk::data::open_data_path();
+}
+@end
+
+namespace dusk {
+namespace {
+
+DuskAppMenuTarget *shared_app_menu_target() {
+  static DuskAppMenuTarget *target = [DuskAppMenuTarget new];
+  return target;
+}
+
+} // namespace
+
+void InstallMacOSAppMenuActions() {
+  NSMenu *mainMenu = [NSApp mainMenu];
+  if (mainMenu == nil || [mainMenu numberOfItems] == 0) {
+    return;
+  }
+
+  NSMenu *appMenu = [[mainMenu itemAtIndex:0] submenu];
+  if (appMenu == nil) {
+    return;
+  }
+
+  if ([appMenu itemWithTitle:@"Open Data Folder..."] != nil) {
+    return;
+  }
+
+  NSUInteger insertIndex = [appMenu numberOfItems];
+
+  for (NSMenuItem *existingItem in [appMenu itemArray]) {
+    if ([existingItem action] == @selector(terminate:)) {
+      insertIndex = [appMenu indexOfItem:existingItem];
+      break;
+    }
+  }
+
+  NSMenuItem *item =
+      [[NSMenuItem alloc] initWithTitle:@"Open Data Folder..."
+                                 action:@selector(openDataFolder:)
+                          keyEquivalent:@""];
+
+  [item setTarget:shared_app_menu_target()];
+  [appMenu insertItem:item atIndex:insertIndex];
+}
+} // namespace dusk

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -92,6 +92,7 @@
 #include "tracy/Tracy.hpp"
 #include <RmlUi/Core.h>
 #ifdef __APPLE__
+#include "dusk/macos_menu.hpp"
 #include <TargetConditionals.h>
 #endif
 
@@ -589,6 +590,11 @@ int game_main(int argc, char* argv[]) {
         config.allowTextureDumps = false;
         auroraInfo = aurora_initialize(argc, argv, &config);
     }
+
+#if defined(__APPLE__) && !TARGET_OS_IOS && !TARGET_OS_TV && !TARGET_OS_MACCATALYST
+    // macOS specific app menu actions
+    dusk::InstallMacOSAppMenuActions();
+#endif
 
 #ifdef DUSK_DISCORD
     if (dusk::getSettings().game.enableDiscordPresence) {


### PR DESCRIPTION
Allows macOS builds to open the Data folder directly from the menu bar instead of going through the in-game options.

Users can click on Dusklight > Open Data Folder... as an alternative of the in-game menu option.

https://github.com/user-attachments/assets/2e15b6f3-baed-4f0f-b99b-2a87774f9ed8

