### PR TITLE
fixes empty howl tab near certain actors

### DIFF
--- a/src/d/actor/d_a_alink_wolf.inc
+++ b/src/d/actor/d_a_alink_wolf.inc
@@ -4005,7 +4005,13 @@ int daAlink_c::procWolfHowlDemoInit() {
         } else if (name == fpcNm_Tag_WaraHowl_e) {
             mZ2WolfHowlMgr.setCorrectCurve(static_cast<daTagWrHowl_c*>(field_0x27f4)->getTuneId());
         } else {
+            #if TARGET_PC
+            if (mZ2WolfHowlMgr.getCorrectCurveID() != 9) {
+                mZ2WolfHowlMgr.setCorrectCurve(-1);
+            }
+            #else
             mZ2WolfHowlMgr.setCorrectCurve(-1);
+            #endif
         }
     } else {
         #if TARGET_PC


### PR DESCRIPTION
When howling suns song near actors that arent howl stones, an empty howl tab was shown. This fixes the issue by duplicating a check for sun's song howling into the relevant code branch.

resolves #1743 