### PR TITLE
Fixes linux credits crash

### DIFF
--- a/libs/JSystem/include/JSystem/J3DGraphBase/J3DMatBlock.h
+++ b/libs/JSystem/include/JSystem/J3DGraphBase/J3DMatBlock.h
@@ -1575,6 +1575,12 @@ struct J3DAlphaComp {
     u8 getRef1() const { return mRef1; }
 
     void load() const {
+#ifdef AVOID_UB
+    if (mID > 255) {
+            J3DGDSetAlphaCompare(GX_ALWAYS, 0, GX_AOP_OR, GX_ALWAYS, 0);
+            return;
+        }
+#endif
         J3DGDSetAlphaCompare((GXCompare)getComp0(), mRef0, (GXAlphaOp)getOp(), (GXCompare)getComp1(), mRef1);
     }
 


### PR DESCRIPTION
alpha comparison mID is u16, but indexes into a 256-item table. this causes MAT3 materials with an alpha comparison index of 0xFFFF crashes on linux

closes #1073
closes #1531