### PR TITLE
store config to disk when destroying ui

### DIFF
--- a/src/dusk/ui/ui.cpp
+++ b/src/dusk/ui/ui.cpp
@@ -15,6 +15,7 @@
 #include "input.hpp"
 #include "prelaunch.hpp"
 #include "window.hpp"
+#include "dusk/config.hpp"
 
 namespace dusk::ui {
 namespace {
@@ -60,6 +61,7 @@ bool initialize() noexcept {
 }
 
 void shutdown() noexcept {
+    config::Save();
     sDocumentStack.clear();
     sPassiveDocuments.clear();
     sConnectedGamepads.clear();


### PR DESCRIPTION
certain ui actions do not call config::Save(), e.g. unbinding action keys. rather than forgetting anywhere else, just save when closing the app