### PR TITLE
Add scroll wheel as an input for stepping NumberButton

### DIFF
--- a/res/rml/window.rcss
+++ b/res/rml/window.rcss
@@ -250,6 +250,11 @@ select-button:not(:disabled):active {
     box-shadow: #C2A42D 0 0 0 2dp;
 }
 
+select-button:not(:disabled).scrollable {
+    z-index: 1;
+    box-shadow: #C2A42D 0 0 0 2dp, rgba(194, 164, 45, 70%) 0 0 12dp 4dp;
+}
+
 select-button:disabled {
     opacity: 0.35;
     cursor: default;

--- a/src/dusk/ui/number_button.cpp
+++ b/src/dusk/ui/number_button.cpp
@@ -13,7 +13,70 @@ NumberButton::NumberButton(Rml::Element* parent, Props props)
       mGetValue(std::move(props.getValue)), mSetValue(std::move(props.setValue)),
       mIsDisabled(std::move(props.isDisabled)), mIsModified(std::move(props.isModified)),
       mMin(props.min), mMax(props.max), mStep(props.step), mPrefix(std::move(props.prefix)),
-      mSuffix(std::move(props.suffix)) {}
+      mSuffix(std::move(props.suffix)) {
+    Component::listen(mRoot, Rml::EventId::Keydown, [this](Rml::Event& event) {
+        if (disabled()) {
+            return;
+        }
+        if (map_nav_event(event) != NavCommand::Confirm) {
+            return;
+        }
+        if (!is_editing()) {
+            start_editing();
+        } else {
+            request_stop_editing(true, true);
+        }
+        event.StopImmediatePropagation();
+    });
+
+    Component::listen(mRoot, Rml::EventId::Click, [this](Rml::Event& event) {
+        if (disabled() || is_editing() || !contains(event.GetTargetElement())) {
+            return;
+        }
+        set_scrollable(!mScrollable);
+        event.StopImmediatePropagation();
+    });
+
+    Component::listen(mRoot, Rml::EventId::Dblclick, [this](Rml::Event& event) {
+        if (disabled() || is_editing() || !contains(event.GetTargetElement())) {
+            return;
+        }
+        start_editing();
+        event.StopImmediatePropagation();
+    });
+
+    Component::listen(mRoot, Rml::EventId::Blur, [this](Rml::Event& event) {
+        if (contains(event.GetTargetElement())) {
+            set_scrollable(false);
+        }
+    });
+
+    Component::listen(mRoot, Rml::EventId::Mouseout, [this](Rml::Event& event) {
+        if (event.GetTargetElement() == mRoot) {
+            set_scrollable(false);
+        }
+    });
+
+    Component::listen(mRoot, Rml::EventId::Mousescroll, [this](Rml::Event& event) {
+        if (disabled() || is_editing() || !mScrollable || !contains(event.GetTargetElement())) {
+            return;
+        }
+
+        const float wheelDeltaY = event.GetParameter("wheel_delta_y", 0.0f);
+        const float absWheelDeltaY = wheelDeltaY < 0.0f ? -wheelDeltaY : wheelDeltaY;
+        if (absWheelDeltaY == 0.0f) {
+            return;
+        }
+
+        const int newValue = std::clamp(mGetValue() + (wheelDeltaY < 0.0f ? 1 : -1) * mStep, mMin, mMax);
+        if (newValue != mGetValue()) {
+            mSetValue(newValue);
+            mDoAud_seStartMenu(kSoundItemChange);
+        }
+
+        event.StopPropagation();
+    });
+}
 
 bool NumberButton::modified() const {
     if (mIsModified) {
@@ -54,6 +117,10 @@ void NumberButton::set_value(Rml::String value) {
 }
 
 bool NumberButton::handle_nav_command(NavCommand cmd) {
+    if (cmd == NavCommand::Confirm) {
+        return false;
+    }
+
     if (!is_editing() && (cmd == NavCommand::Left || cmd == NavCommand::Right)) {
         const int newValue = std::clamp(
             mGetValue() + (cmd == NavCommand::Right ? mStep : -mStep), mMin, mMax);
@@ -66,4 +133,12 @@ bool NumberButton::handle_nav_command(NavCommand cmd) {
     return BaseStringButton::handle_nav_command(cmd);
 }
 
+void NumberButton::set_scrollable(bool value) {
+    mScrollable = value;
+    mRoot->SetClass("scrollable", value);
+}
+
+void NumberButton::on_editing_started() {
+    set_scrollable(false);
+}
 }  // namespace dusk::ui

--- a/src/dusk/ui/number_button.hpp
+++ b/src/dusk/ui/number_button.hpp
@@ -31,6 +31,8 @@ protected:
     Rml::String input_value() override;
     void set_value(Rml::String value) override;
     bool handle_nav_command(NavCommand cmd) override;
+    void set_scrollable(bool value);
+    void on_editing_started() override;
 
 private:
     std::function<int()> mGetValue;
@@ -40,6 +42,7 @@ private:
     int mMin;
     int mMax;
     int mStep;
+    bool mScrollable = false;
     Rml::String mPrefix;
     Rml::String mSuffix;
 };

--- a/src/dusk/ui/string_button.cpp
+++ b/src/dusk/ui/string_button.cpp
@@ -41,6 +41,7 @@ void BaseStringButton::start_editing() {
         mInputElem->SetAttribute("maxlength", mMaxLength);
     }
     mRoot->AppendChild(std::move(elemPtr));
+    on_editing_started();
 
     // Hide value element
     mValueElem->SetProperty(Rml::PropertyId::Visibility, Rml::Style::Visibility::Hidden);

--- a/src/dusk/ui/string_button.hpp
+++ b/src/dusk/ui/string_button.hpp
@@ -21,6 +21,7 @@ public:
 
 protected:
     bool is_editing() { return mInputElem != nullptr; }
+    virtual void on_editing_started() {}
     bool handle_nav_command(NavCommand cmd) override;
     virtual void set_value(Rml::String value) = 0;
     virtual Rml::String input_value() { return format_value(); }


### PR DESCRIPTION
Allows stepping NumberButton options using your scroll wheel. Clicking a NumberButton once now starts scroll consumption, and editing has been relegated to a double click. Scroll consumption is indicated by a glow effect, and is cancelled either by another click, a double clock, or a mouseout/blur event.

There might be a better solution here but I couldn't think of it, please critique into oblivion if necessary.