### PR TITLE
Adjust Percentage Completion for Glitched Achievements

### DIFF
--- a/src/dusk/ui/achievements.cpp
+++ b/src/dusk/ui/achievements.cpp
@@ -217,7 +217,7 @@ void AchievementsWindow::updateTotal() {
         return;
     }
     const auto all = AchievementSystem::get().getAchievements();
-    int total = static_cast<int>(all.size());
+    const int total = std::count_if(all.begin(), all.end(), [](const Achievement& achievement){ return achievement.category != AchievementCategory::Glitched;});
     int unlocked = 0;
     for (const auto& a : all) {
         if (a.unlocked) {


### PR DESCRIPTION
Make glitched achievements put the percentage above 100%. Getting glitched achievements before finishing the rest allows you to hit 100% also, but based on some prior team discussion that seems like reasonable behavior.