### PR TITLE
Invincible Link

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -230,6 +230,7 @@ struct UserSettings {
         ConfigVar<bool> fastSpinner;
         ConfigVar<bool> freeMagicArmor;
         ConfigVar<bool> invincibleEnemies;
+        ConfigVar<bool> invincibleLink;
 
         // Technical
         ConfigVar<bool> restoreWiiGlitches;

--- a/src/d/actor/d_a_alink_damage.inc
+++ b/src/d/actor/d_a_alink_damage.inc
@@ -202,7 +202,12 @@ int daAlink_c::setDamagePoint(int i_dmgAmount, BOOL i_checkZoraMag, BOOL i_setDm
     if (!mpHIO->mDamage.m.mInvincible && g_debugHpMode == 0)
     #endif
     {
-        dComIfGp_setItemLifeCount(-i_dmgAmount, 0);
+#if TARGET_PC
+        if (!dusk::getSettings().game.invincibleLink)
+#endif
+        {
+            dComIfGp_setItemLifeCount(-i_dmgAmount, 0);
+        }
     }
 
 #if TARGET_PC
@@ -489,6 +494,12 @@ BOOL daAlink_c::checkDamageAction() {
         }
         return 0;
     }
+
+#if TARGET_PC
+    if (dusk::getSettings().game.invincibleLink) {
+        return checkWolfBarrierHitReverse();
+    }
+#endif
 
     if (mDamageTimer != 0) {
         return checkWolfBarrierHitReverse();

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -123,6 +123,7 @@ UserSettings g_userSettings = {
         .fastSpinner {"game.fastSpinner", false},
         .freeMagicArmor {"game.freeMagicArmor", false},
         .invincibleEnemies {"game.invincibleEnemies", false},
+        .invincibleLink {"game.invincibleLink", false},
 
         // Technical
         .restoreWiiGlitches {"game.restoreWiiGlitches", false},
@@ -280,6 +281,7 @@ void registerSettings() {
     Register(g_userSettings.game.superClawshot);
     Register(g_userSettings.game.alwaysGreatspin);
     Register(g_userSettings.game.invincibleEnemies);
+    Register(g_userSettings.game.invincibleLink);
     Register(g_userSettings.game.enableFrameInterpolation);
     Register(g_userSettings.game.gyroMode);
     Register(g_userSettings.game.enableGyroAim);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -213,6 +213,7 @@ void reset_for_speedrun_mode() {
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);
     getSettings().game.invincibleEnemies.setSpeedrunValue(false);
+    getSettings().game.invincibleLink.setSpeedrunValue(false);
 
     getSettings().game.pauseOnFocusLost.setSpeedrunValue(false);
     aurora_set_pause_on_focus_lost(false);
@@ -1294,6 +1295,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Lets the magic armor work without consuming rupees.");
         addCheat("Invincible Enemies", getSettings().game.invincibleEnemies,
             "Prevents enemies from taking damage.");
+        addCheat("Invincible Link", getSettings().game.invincibleLink,
+            "Makes Link ignore all incoming damage");
     });
 
     add_tab("Interface", [this](Rml::Element* content) {

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1296,7 +1296,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         addCheat("Invincible Enemies", getSettings().game.invincibleEnemies,
             "Prevents enemies from taking damage.");
         addCheat("Invincible Link", getSettings().game.invincibleLink,
-            "Makes Link ignore all incoming damage");
+            "Makes Link ignore all incoming damage.");
     });
 
     add_tab("Interface", [this](Rml::Element* content) {


### PR DESCRIPTION
As requested in https://github.com/TwilitRealm/dusklight/issues/1883 and https://github.com/TwilitRealm/dusklight/issues/1861. These changes introduce an invincible mode for Link. Enabling this will result in damage not being registered and Link not getting stunned or receiving knockback. 

<img width="1256" height="873" alt="image" src="https://github.com/user-attachments/assets/42532d4c-d4cc-41d0-9fbc-63fdd0c10e11" />
