### PR TITLE
Crash Reporting Option Portability

### DIFF
--- a/src/dusk/crash_reporting.cpp
+++ b/src/dusk/crash_reporting.cpp
@@ -61,7 +61,7 @@ std::string release_name() {
 }
 
 std::filesystem::path sentry_database_path() {
-    return dusk::CachePath / "sentry";
+    return dusk::ConfigPath / "sentry";
 }
 
 std::filesystem::path log_attachment_path() {


### PR DESCRIPTION
Still has details I need to iron out. Goal is to preserve the crash report setting if people change devices with a portable install.