### PR TITLE
Minimap size configuration option

### DIFF
--- a/include/d/d_meter_map.h
+++ b/include/d/d_meter_map.h
@@ -119,6 +119,10 @@ private:
     /* 0x2D */ u8 mMapIsInside;
     /* 0x2E */ u8 field_0x2e;
     /* 0x30 */ int field_0x30;
+#if TARGET_PC
+    f32 mBaseSizeW;
+    f32 mBaseSizeH;
+#endif
 };
 
 #endif /* D_METER_D_METER_MAP_H */

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -162,6 +162,7 @@ struct UserSettings {
         // Preferences
         ConfigVar<bool> enableMirrorMode;
         ConfigVar<bool> minimalHUD;
+        ConfigVar<float> minimapSize;
         ConfigVar<bool> pauseOnFocusLost;
         ConfigVar<bool> enableLinkDollRotation;
         ConfigVar<bool> enableAchievementToasts;

--- a/src/d/d_meter_map.cpp
+++ b/src/d/d_meter_map.cpp
@@ -16,6 +16,7 @@
 #include "f_op/f_op_overlap_mng.h"
 #include "m_Do/m_Do_controller_pad.h"
 #include "d/d_camera.h"
+#include "dusk/settings.h"
 #include <cstring>
 
 #if (PLATFORM_WII || PLATFORM_SHIELD)
@@ -444,6 +445,11 @@ void dMeterMap_c::_create(J2DScreen* unused) {
     mSizeW = (s16)sizeX;
     mSizeH = (s16)sizeY;
 
+#if TARGET_PC
+    mBaseSizeW = mSizeW;
+    mBaseSizeH = mSizeH;
+#endif
+
     mMap = JKR_NEW dMap_c(sizeX, sizeY, dispSizeW, dispSizeH);
     JUT_ASSERT(999, mMap != NULL);
 
@@ -577,6 +583,20 @@ void dMeterMap_c::_move(u32 param_0) {
 
     mSizeW = (s16)sizeW;
     mSizeH = (s16)sizeH;
+    #endif
+
+    #if TARGET_PC
+    {
+        f32 scale = dusk::getSettings().game.minimapSize;
+        if (scale < 0.10f) {
+            scale = 0.10f;
+        } else if (scale > 3.0f) {
+            scale = 3.0f;
+        }
+
+        mSizeW = mBaseSizeW * scale;
+        mSizeH = mBaseSizeH * scale;
+    }
     #endif
 
     mDrawPosX = mSlidePositionOffset + getMapDispEdgeLeftX_Layout();

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -50,6 +50,7 @@ UserSettings g_userSettings = {
         // Preferences
         .enableMirrorMode {"game.enableMirrorMode", false},
         .minimalHUD {"game.minimalHUD", false},
+        .minimapSize {"game.minimapSize", 1.0f},
         .pauseOnFocusLost {"game.pauseOnFocusLost", false},
         .enableLinkDollRotation {"game.enableLinkDollRotation", false},
         .enableAchievementToasts {"game.enableAchievementToasts", true},
@@ -238,6 +239,7 @@ void registerSettings() {
     Register(g_userSettings.game.freeCameraXSensitivity);
     Register(g_userSettings.game.freeCameraYSensitivity);
     Register(g_userSettings.game.minimalHUD);
+    Register(g_userSettings.game.minimapSize);
     Register(g_userSettings.game.pauseOnFocusLost);
     Register(g_userSettings.game.enableDiscordPresence);
     Register(g_userSettings.game.bloomMode);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1470,6 +1470,9 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 pane.add_rml("<br/>Changes how the Collection and File Select menus scale to your "
                              "aspect ratio.");
             });
+        config_percent_select(leftPane, rightPane, getSettings().game.minimapSize, "Minimap Size",
+            "Scales the Minimap.<br/><br/>"
+            "Lower it if the Minimap feels too large, such as on a big TV.", 20, 150);
         config_bool_select(leftPane, rightPane, getSettings().game.hideTvSettingsScreen,
             {
                 .key = "Skip TV Settings Screen",


### PR DESCRIPTION
As requested in https://github.com/TwilitRealm/dusklight/issues/1958 these changes introduce the ability to configure the minimap size in-game. It allows for a range of 25%-150%, which should be enough for TVs and other displays. 

**Before (100%):**
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/1f38cde1-edb0-41aa-a0e0-17ae59565489" />

<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/5b3a9375-43d2-44f8-8182-b61aaaf419e2" />


**After:**

<img width="1710" height="1078" alt="image" src="https://github.com/user-attachments/assets/724e9262-5832-4970-bd94-391d8633e2ea" />

<img width="1710" height="1075" alt="image" src="https://github.com/user-attachments/assets/fcd41530-99d5-45de-9ca3-804dda255bff" />
