### PR TITLE
Clamp flycam FOV

### DIFF
--- a/src/dusk/imgui/ImGuiCameraOverlay.cpp
+++ b/src/dusk/imgui/ImGuiCameraOverlay.cpp
@@ -49,7 +49,9 @@ namespace dusk {
             dCam->Reset(center, eye);
         }
 
-        ImGui::InputFloat("Camera FOV", &dCam->mFovy);
+        if (ImGui::InputFloat("Camera FOV", &dCam->mFovy)) {
+            dCam->mFovy = std::clamp(dCam->mFovy, 0.1f, 179.9f);
+        }
 
         ImGui::SeparatorText("Options");
 


### PR DESCRIPTION
Prevents an assert fail crash if you type an invalid value into the field (which is very easy to do).