### PR TITLE
Restore Green Chu Merging

### DIFF
--- a/src/d/actor/d_a_e_sm2.cpp
+++ b/src/d/actor/d_a_e_sm2.cpp
@@ -923,6 +923,14 @@ static void damage_check(e_sm2_class* i_this) {
                         sm_hit_actor->mode = 10;
 
                         u8 new_color_type = new_col_d[(sm_hit_actor->type * 7) + i_this->type];
+                        #if TARGET_PC
+                        if (dusk::getSettings().game.restoreWiiGlitches &&
+                            ((sm_hit_actor->type == TYPE_BLUE && i_this->type == TYPE_YELLOW) ||
+                                (sm_hit_actor->type == TYPE_YELLOW && i_this->type == TYPE_BLUE)))
+                        {
+                            new_color_type = TYPE_GREEN;
+                        }
+                        #endif
                         i_this->type = new_color_type;
                         sm_hit_actor->type = new_color_type;
 


### PR DESCRIPTION
Restores Wii/HD Green Chu merging behaviour, encounterable in room 19 of the Cave of Ordeals. This functionality has been integrated into the existing "Restore Wii 1.0 Glitches" setting.