### PR TITLE
Add "Bug Spray" cheat

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -236,6 +236,7 @@ struct UserSettings {
         ConfigVar<bool> fastSpinner;
         ConfigVar<bool> freeMagicArmor;
         ConfigVar<bool> invincibleEnemies;
+        ConfigVar<bool> bugSpray;
 
         // Technical
         ConfigVar<bool> restoreWiiGlitches;

--- a/src/d/actor/d_a_e_bug.cpp
+++ b/src/d/actor/d_a_e_bug.cpp
@@ -629,6 +629,17 @@ static void bug_control(e_bug_class* a_this) {
 
             i_this->field_0x52++;
 
+#if TARGET_PC
+            if (dusk::getSettings().game.bugSpray) {
+                if (i_this->field_0x50 == 2) {
+                    // state: "gonna attach myself"
+                    // no, you're not
+                    i_this->field_0x50 = 4;
+                    // state: "nice try"
+                }
+            }
+#endif
+
             if (i_this->field_0x50 == -1) {
                 set_wait(a_this, i_this);
                 bug_mtxset(i_this);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -129,6 +129,7 @@ UserSettings g_userSettings = {
         .fastSpinner {"game.fastSpinner", false},
         .freeMagicArmor {"game.freeMagicArmor", false},
         .invincibleEnemies {"game.invincibleEnemies", false},
+        .bugSpray {"game.bugSpray", false},
 
         // Technical
         .restoreWiiGlitches {"game.restoreWiiGlitches", false},
@@ -288,6 +289,7 @@ void registerSettings() {
     Register(g_userSettings.game.superClawshot);
     Register(g_userSettings.game.alwaysGreatspin);
     Register(g_userSettings.game.invincibleEnemies);
+    Register(g_userSettings.game.bugSpray);
     Register(g_userSettings.game.enableFrameInterpolation);
     Register(g_userSettings.game.enableGyroAim);
     Register(g_userSettings.game.enableGyroRollgoal);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -213,6 +213,7 @@ void reset_for_speedrun_mode() {
     getSettings().game.fastSpinner.setSpeedrunValue(false);
     getSettings().game.freeMagicArmor.setSpeedrunValue(false);
     getSettings().game.invincibleEnemies.setSpeedrunValue(false);
+    getSettings().game.bugSpray.setSpeedrunValue(false);
 
     getSettings().game.pauseOnFocusLost.setSpeedrunValue(false);
     aurora_set_pause_on_focus_lost(false);
@@ -1276,6 +1277,8 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             "Lets the magic armor work without consuming rupees.");
         addCheat("Invincible Enemies", getSettings().game.invincibleEnemies,
             "Prevents enemies from taking damage.");
+        addCheat("Bug Spray", getSettings().game.bugSpray,
+            "Poison Mites die instead of attaching themselves to and slowing down Link.");
     });
 
     add_tab("Interface", [this](Rml::Element* content) {


### PR DESCRIPTION
Prevents Poison Mites (in Arbiter's Grounds) from attaching to Link and slowing him down. Can probably be considered an accessibility feature for players with entomophobia.

Ghoul Rats (which are easier to defend against) may still attach to Link. Golden Bugs remain collectible.

Also proves that there is a subtle difference between "fixing bugs" and "removing bugs"...