### PR TITLE
Adds a second swappable set of items.

### DIFF
--- a/include/dusk/action_bindings.h
+++ b/include/dusk/action_bindings.h
@@ -11,6 +11,7 @@ enum class ActionBinds {
     CALL_MIDNA,
     OPEN_DUSKLIGHT_MENU,
     TURBO_SPEED_BUTTON,
+    SWAP_ITEMS,
     COUNT,
 };
 

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -286,6 +286,7 @@ struct UserSettings {
         std::array<ActionBindConfigVar, 4> callMidna;
         std::array<ActionBindConfigVar, 4> openDusklightMenu;
         std::array<ActionBindConfigVar, 4> turboSpeedButton;
+        std::array<ActionBindConfigVar, 4> swapItems;
     } actionBindings;
 };
 

--- a/src/d/d_menu_ring.cpp
+++ b/src/d/d_menu_ring.cpp
@@ -32,6 +32,7 @@
 #if TARGET_PC
 #include "dusk/game_clock.h"
 #include "dusk/settings.h"
+#include "dusk/action_bindings.h"
 #endif
 
 typedef void (dMenu_Ring_c::*initFunc)();
@@ -1502,6 +1503,19 @@ void dMenu_Ring_c::stick_wait_init() {
 }
 
 void dMenu_Ring_c::stick_wait_proc() {
+    #if TARGET_PC
+    if (dusk::isActionBound(dusk::ActionBinds::SWAP_ITEMS, 0)) {
+        if (dusk::getActionBindTrig(dusk::ActionBinds::SWAP_ITEMS, 0)) {
+            u8 item_x = dComIfGs_getSelectItemIndex(0);
+            u8 item_y = dComIfGs_getSelectItemIndex(1);
+            dComIfGs_setSelectItemIndex(0, dComIfGs_getSelectItemIndex(2)); // GC X, Wii D-Left
+            dComIfGs_setSelectItemIndex(1, dComIfGs_getSelectItemIndex(3)); // GC Y, Wii D-right
+            dComIfGs_setSelectItemIndex(2, item_x); // Wii Dpad Down
+            dComIfGs_setSelectItemIndex(3, item_y); // Wii B
+            Z2GetAudioMgr()->seStart(Z2SE_SY_ITEM_SET_X, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+        }
+    }
+    #endif
     u8 item = dComIfGs_getItem(mItemSlots[mCurrentSlot], false);
 
     if (item != dItemNo_NONE_e) {

--- a/src/d/d_menu_window.cpp
+++ b/src/d/d_menu_window.cpp
@@ -28,6 +28,7 @@
 
 #ifdef TARGET_PC
 #include "dusk/frame_interpolation.h"
+#include "dusk/action_bindings.h"
 #endif
 
 class dDlst_MENU_CAPTURE_c : public dDlst_base_c {
@@ -547,6 +548,19 @@ void dMw_c::insect_close_init(u8) {
 }
 
 void dMw_c::key_wait_proc() {
+    #if TARGET_PC
+    if (dusk::isActionBound(dusk::ActionBinds::SWAP_ITEMS, 0)) {
+        if (dusk::getActionBindTrig(dusk::ActionBinds::SWAP_ITEMS, 0)) {
+            u8 item_x = dComIfGs_getSelectItemIndex(0);
+            u8 item_y = dComIfGs_getSelectItemIndex(1);
+            dComIfGs_setSelectItemIndex(0, dComIfGs_getSelectItemIndex(2)); // GC X, Wii D-Left
+            dComIfGs_setSelectItemIndex(1, dComIfGs_getSelectItemIndex(3)); // GC Y, Wii D-right
+            dComIfGs_setSelectItemIndex(2, item_x); // Wii Dpad Down
+            dComIfGs_setSelectItemIndex(3, item_y); // Wii B
+            Z2GetAudioMgr()->seStart(Z2SE_SY_ITEM_SET_X, NULL, 0, 0, 1.0f, 1.0f, -1.0f, -1.0f, 0);
+        }
+    }
+    #endif
     if (field_0x14B != 0) {
         switch (field_0x14B) {
         case 1:

--- a/src/dusk/action_bindings.cpp
+++ b/src/dusk/action_bindings.cpp
@@ -14,6 +14,7 @@ ActionBindsMap& getActionBinds() {
         {ActionBinds::CALL_MIDNA,          {&getSettings().actionBindings.callMidna,         "Call Midna"}},
         {ActionBinds::OPEN_DUSKLIGHT_MENU, {&getSettings().actionBindings.openDusklightMenu, "Open Dusklight Menu"}},
         {ActionBinds::TURBO_SPEED_BUTTON,  {&getSettings().actionBindings.turboSpeedButton,  "Turbo Speed Button"}},
+        {ActionBinds::SWAP_ITEMS,        {&getSettings().actionBindings.swapItems,       "Quick Swap Items"}},
     };
     return actionBinds;
 }

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -185,6 +185,12 @@ UserSettings g_userSettings = {
             ActionBindConfigVar{"actionBindings.turboButton_port2", PAD_NATIVE_BUTTON_INVALID},
             ActionBindConfigVar{"actionBindings.turboButton_port3", PAD_NATIVE_BUTTON_INVALID},
         },
+        .swapItems {
+            ActionBindConfigVar{"actionBingings.swapItems_port0", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBingings.swapItems_port1", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBingings.swapItems_port2", PAD_NATIVE_BUTTON_INVALID},
+            ActionBindConfigVar{"actionBingings.swapItems_port3", PAD_NATIVE_BUTTON_INVALID},
+        },
     }
 };
 
@@ -339,6 +345,10 @@ void registerSettings() {
     Register(g_userSettings.actionBindings.turboSpeedButton[1]);
     Register(g_userSettings.actionBindings.turboSpeedButton[2]);
     Register(g_userSettings.actionBindings.turboSpeedButton[3]);
+    Register(g_userSettings.actionBindings.swapItems[0]);
+    Register(g_userSettings.actionBindings.swapItems[1]);
+    Register(g_userSettings.actionBindings.swapItems[2]);
+    Register(g_userSettings.actionBindings.swapItems[3]);
 }
 
 // Transient settings


### PR DESCRIPTION
Adds a custom action bind that allows swapping between a "front" and "back" item set

Wii has 4 slots for equippable items so "back" set is stored on the extra slots in the save data

Not ready for merge; Odd behavior when making a bow combo where a hero's bow lands on the same button on the other set, but gets cleared away when undoing the combo.
probably just me not knowing how setselectitemindex works correctly

Would also like to make dmeter flash the item icons like when they're newly equipped to highlight what happens other than the sound effect