### PR TITLE
Add setting to memorize window size

### DIFF
--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -134,6 +134,9 @@ struct UserSettings {
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
         ConfigVar<int> maxFrameRate;
+        ConfigVar<bool> memorizeWindowSize;
+        ConfigVar<int> lastWindowWidth;
+        ConfigVar<int> lastWindowHeight;
     } video;
 
     struct {

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -134,7 +134,7 @@ struct UserSettings {
         ConfigVar<bool> enableFpsOverlay;
         ConfigVar<int> fpsOverlayCorner;
         ConfigVar<int> maxFrameRate;
-        ConfigVar<bool> memorizeWindowSize;
+        ConfigVar<bool> rememberWindowSize;
         ConfigVar<int> lastWindowWidth;
         ConfigVar<int> lastWindowHeight;
     } video;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -11,6 +11,9 @@ UserSettings g_userSettings = {
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
         .maxFrameRate {"video.maxFrameRate", 240},
+        .memorizeWindowSize {"video.memorizeWindowSize", false},
+        .lastWindowWidth {"video.lastWindowWidth", 0},
+        .lastWindowHeight {"video.lastWindowHeight", 0},
     },
 
     .audio = {
@@ -200,6 +203,9 @@ void registerSettings() {
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
     Register(g_userSettings.video.maxFrameRate);
+    Register(g_userSettings.video.memorizeWindowSize);
+    Register(g_userSettings.video.lastWindowWidth);
+    Register(g_userSettings.video.lastWindowHeight);
 
     // Audio
     Register(g_userSettings.audio.masterVolume);

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -11,7 +11,7 @@ UserSettings g_userSettings = {
         .enableFpsOverlay {"game.enableFpsOverlay", false},
         .fpsOverlayCorner {"game.fpsOverlayCorner", 0},
         .maxFrameRate {"video.maxFrameRate", 240},
-        .memorizeWindowSize {"video.memorizeWindowSize", false},
+        .rememberWindowSize {"video.rememberWindowSize", false},
         .lastWindowWidth {"video.lastWindowWidth", 0},
         .lastWindowHeight {"video.lastWindowHeight", 0},
     },
@@ -203,7 +203,7 @@ void registerSettings() {
     Register(g_userSettings.video.enableFpsOverlay);
     Register(g_userSettings.video.fpsOverlayCorner);
     Register(g_userSettings.video.maxFrameRate);
-    Register(g_userSettings.video.memorizeWindowSize);
+    Register(g_userSettings.video.rememberWindowSize);
     Register(g_userSettings.video.lastWindowWidth);
     Register(g_userSettings.video.lastWindowHeight);
 

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -802,6 +802,21 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 pane.add_rml(
                     "<br/>Display the current framerate in a corner of the screen while playing.");
             });
+        config_bool_select(leftPane, rightPane, getSettings().video.memorizeWindowSize,
+            {
+                .key = "Memorize Window Size",
+                .helpText = "Memorize the window's dimensions and restore them at the next startup. Fullscreen can still be toggled independently.",
+                .onChange =
+                    [](bool value) {
+                        if (value && !dusk::getSettings().video.enableFullscreen) {
+                            const auto windowSize = aurora::window::get_window_size();
+                            dusk::getSettings().video.lastWindowWidth.setValue(windowSize.width);
+                            dusk::getSettings().video.lastWindowHeight.setValue(windowSize.height);
+                            dusk::config::Save();
+                        }
+                    },
+                .isDisabled = [] { return IsMobile; },
+            });
         leftPane.add_section("Resolution");
         graphics_tuner_control(*this, leftPane, rightPane,
             getSettings().game.internalResolutionScale,

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -802,10 +802,10 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                 pane.add_rml(
                     "<br/>Display the current framerate in a corner of the screen while playing.");
             });
-        config_bool_select(leftPane, rightPane, getSettings().video.memorizeWindowSize,
+        config_bool_select(leftPane, rightPane, getSettings().video.rememberWindowSize,
             {
-                .key = "Memorize Window Size",
-                .helpText = "Memorize the window's dimensions and restore them at the next startup. Fullscreen can still be toggled independently.",
+                .key = "Remember Window Size",
+                .helpText = "Save and restore the previous session's window size when opening Dusklight.",
                 .onChange =
                     [](bool value) {
                         if (value && !dusk::getSettings().video.enableFullscreen) {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -260,7 +260,7 @@ void main01(void) {
                 dusk::g_imguiConsole.HandleSDLEvent(event->sdl);
                 break;
             case AURORA_WINDOW_RESIZED:
-                if (dusk::getSettings().video.memorizeWindowSize && !dusk::getSettings().video.enableFullscreen) {
+                if (dusk::getSettings().video.rememberWindowSize && !dusk::getSettings().video.enableFullscreen) {
                     dusk::getSettings().video.lastWindowWidth.setValue(event->windowSize.width);
                     dusk::getSettings().video.lastWindowHeight.setValue(event->windowSize.height);
                     dusk::config::Save();
@@ -595,7 +595,7 @@ int game_main(int argc, char* argv[]) {
         const int lastWindowWidth = dusk::getSettings().video.lastWindowWidth.getValue();
         const int lastWindowHeight = dusk::getSettings().video.lastWindowHeight.getValue();
 
-        if (dusk::getSettings().video.memorizeWindowSize && lastWindowWidth > 0 && lastWindowHeight > 0) {
+        if (dusk::getSettings().video.rememberWindowSize && lastWindowWidth > 0 && lastWindowHeight > 0) {
             config.windowWidth = lastWindowWidth;
             config.windowHeight = lastWindowHeight;
         } else {

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -591,17 +591,16 @@ int game_main(int argc, char* argv[]) {
         config.startFullscreen = dusk::getSettings().video.enableFullscreen;
         config.windowPosX = -1;
         config.windowPosY = -1;
-        config.windowWidth = defaultWindowWidth * 2;
-        config.windowHeight = defaultWindowHeight * 2;
 
-        if (dusk::getSettings().video.memorizeWindowSize) {
-            int width = dusk::getSettings().video.lastWindowWidth.getValue();
-            int height = dusk::getSettings().video.lastWindowHeight.getValue();
+        const int lastWindowWidth = dusk::getSettings().video.lastWindowWidth.getValue();
+        const int lastWindowHeight = dusk::getSettings().video.lastWindowHeight.getValue();
 
-            if (width > 0 && height > 0) {
-                config.windowWidth = width;
-                config.windowHeight = height;
-            }
+        if (dusk::getSettings().video.memorizeWindowSize && lastWindowWidth > 0 && lastWindowHeight > 0) {
+            config.windowWidth = lastWindowWidth;
+            config.windowHeight = lastWindowHeight;
+        } else {
+            config.windowWidth = defaultWindowWidth * 2;
+            config.windowHeight = defaultWindowHeight * 2;
         }
 
         config.desiredBackend = ResolveDesiredBackend(parsed_arg_options);

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -259,6 +259,13 @@ void main01(void) {
                 dusk::ui::handle_event(event->sdl);
                 dusk::g_imguiConsole.HandleSDLEvent(event->sdl);
                 break;
+            case AURORA_WINDOW_RESIZED:
+                if (dusk::getSettings().video.memorizeWindowSize && !dusk::getSettings().video.enableFullscreen) {
+                    dusk::getSettings().video.lastWindowWidth.setValue(event->windowSize.width);
+                    dusk::getSettings().video.lastWindowHeight.setValue(event->windowSize.height);
+                    dusk::config::Save();
+                }
+                break;
             case AURORA_DISPLAY_SCALE_CHANGED:
                 dusk::ImGuiEngine_Initialize(event->windowSize.scale);
                 break;
@@ -586,6 +593,17 @@ int game_main(int argc, char* argv[]) {
         config.windowPosY = -1;
         config.windowWidth = defaultWindowWidth * 2;
         config.windowHeight = defaultWindowHeight * 2;
+
+        if (dusk::getSettings().video.memorizeWindowSize) {
+            int width = dusk::getSettings().video.lastWindowWidth.getValue();
+            int height = dusk::getSettings().video.lastWindowHeight.getValue();
+
+            if (width > 0 && height > 0) {
+                config.windowWidth = width;
+                config.windowHeight = height;
+            }
+        }
+
         config.desiredBackend = ResolveDesiredBackend(parsed_arg_options);
         config.logCallback = &aurora_log_callback;
         config.logLevel = startupLogLevel;


### PR DESCRIPTION
Until now, Dusklight would either start at a window size of twice the "default resolution" of 608x448, or start in fullscreen if it had been toggled in the last session. With this new setting, resizing the window will immediately save the new window size in settings, so that it can be restored at the next startup.

I added this mostly as a way to get familiar with the codebase, feedback is appreciated!

<img width="1154" height="680" alt="image" src="https://github.com/user-attachments/assets/8a610b65-73f0-4708-a7cd-d184857be66e" />
