### PR TITLE
fix missing zlib dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,13 @@ set(GAME_LIBS aurora::core aurora::gx aurora::gd aurora::si aurora::vi aurora::p
     aurora::card freeverb cxxopts::cxxopts absl::flat_hash_map nlohmann_json::nlohmann_json TracyClient fmt::fmt
     Threads::Threads)
 
+find_package(zstd CONFIG REQUIRED)
+if (NOT TARGET zstd::libzstd)
+  add_library(zstd::libzstd INTERFACE IMPORTED)
+  set_property(TARGET zstd::libzstd PROPERTY
+    INTERFACE_LINK_LIBRARIES zstd)
+endif()
+
 list(APPEND GAME_LIBS zstd::libzstd)
 
 if (DUSK_ENABLE_SENTRY_NATIVE)


### PR DESCRIPTION
Somehow, when building on certain branches (randomizer), zlib cannot be found. On my machine it links properly on main branch, but not on randomizer. Either way, after checking through some issues on related projects, [this issue](http://github.com/yhirose/cpp-httplib/issues/2313) had the same issue and a solution that worked to solve the missing dependency.