### PR TITLE
flake.nix: patchelf libvulkan

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -269,6 +269,12 @@
                       runHook postInstall
                     '';
 
+                postFixup = lib.optionalString (!isDarwin) ''
+                  patchelf \
+                    --add-needed "${pkgs.vulkan-loader}/lib/libvulkan.so" \
+                    $out/bin/dusklight
+                '';
+
                 dontStrip = true;
 
                 meta = {


### PR DESCRIPTION
Since aurora 7ccdae18077caa67acb0f61a525aa5a423cc3b2c, dusklight can't find libvulkan.so on nix