### PR TITLE
Sleep mode desync fix for save file timestamps

### DIFF
--- a/libs/dolphin/src/card/CARDCreate.c
+++ b/libs/dolphin/src/card/CARDCreate.c
@@ -1,5 +1,5 @@
 #include <dolphin/card.h>
-
+#include <chrono>
 #include "__card.h"
 
 // prototypes

--- a/libs/dolphin/src/card/CARDCreate.c
+++ b/libs/dolphin/src/card/CARDCreate.c
@@ -35,7 +35,7 @@ static void CreateCallbackFat(s32 chan, s32 result) {
         card->fileInfo->offset = 0;
         card->fileInfo->iBlock = ent->startBlock;
         // Use system_clock to report time on saves in order to circumvent sleep mode desyncs.
-        ent->time = OSTicksToSeconds(chrono::system_clock::now());
+        ent->time = chrono::system_clock::now();
         result = __CARDUpdateDir(chan, callback);
         if (result < 0) {
             goto after;

--- a/libs/dolphin/src/card/CARDCreate.c
+++ b/libs/dolphin/src/card/CARDCreate.c
@@ -34,7 +34,8 @@ static void CreateCallbackFat(s32 chan, s32 result) {
         CARDSetIconSpeed(ent, 0, CARD_STAT_SPEED_FAST);
         card->fileInfo->offset = 0;
         card->fileInfo->iBlock = ent->startBlock;
-        ent->time = OSTicksToSeconds(OSGetTime());
+        // Use system_clock to report time on saves in order to circumvent sleep mode desyncs.
+        ent->time = OSTicksToSeconds(chrono::system_clock::now());
         result = __CARDUpdateDir(chan, callback);
         if (result < 0) {
             goto after;

--- a/libs/revolution/src/card/CARDCreate.c
+++ b/libs/revolution/src/card/CARDCreate.c
@@ -1,5 +1,5 @@
 #include <revolution/card.h>
-
+#include <chrono>
 #include "__card.h"
 
 // prototypes
@@ -34,7 +34,7 @@ static void CreateCallbackFat(s32 chan, s32 result) {
         CARDSetIconSpeed(ent, 0, CARD_STAT_SPEED_FAST);
         card->fileInfo->offset = 0;
         card->fileInfo->iBlock = ent->startBlock;
-        ent->time = OSTicksToSeconds(OSGetTime());
+        ent->time = chrono::system_clock::now();
         result = __CARDUpdateDir(chan, callback);
         if (result < 0) {
             goto after;


### PR DESCRIPTION
Replace getting time from steady_clock with system_clock while creating saves to account for a sleep mode desync bug/limitation. Intent is for changes to only be user-facing and not affect game logic.