### PR TITLE
Various Mirror Mode Fixes

### DIFF
--- a/src/d/d_camera.cpp
+++ b/src/d/d_camera.cpp
@@ -7602,6 +7602,10 @@ bool dCamera_c::executeDebugFlyCam() {
         sFlyCamLastMousePos = mouseValid ? io.MousePos : ImVec2{-1.0f, -1.0f};
     }
 
+    if (dusk::getSettings().game.enableMirrorMode) {
+        stickX *= -1.0f;
+    }
+
     f32 verticalDisp = 0.0f;
     if (trigR >= FLYCAM_TRIGGER_DEADZONE) {
         verticalDisp += trigR;

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -426,6 +426,13 @@ void dMenu_Fmap2DBack_c::draw() {
         }
 
         mpPointParent->setAlphaRate(mArrowAlpha * mSpotTextureFadeAlpha);
+
+        #ifdef TARGET_PC
+        if (dusk::getSettings().game.enableMirrorMode) {
+            mArrowPos2DX = getMirrorPosX(mArrowPos2DX,0.0f);
+        }
+        #endif
+
         mpPointParent->translate(mArrowPos2DX + mTransX, mArrowPos2DY + mTransZ);
         mpPointScreen->draw(0.0f, 0.0f, grafPort);
     }
@@ -744,8 +751,8 @@ void dMenu_Fmap2DBack_c::zoomMapCalc(f32 i_zoom) {
         f32 tmp = (mRegionMinMapY[mRegionCursor] + mRegionMapSizeY[mRegionCursor] * 0.5f) - dVar11;
 
         f32 tmp2 = (dVar12 + (i_zoom * (centerX - dVar12)));
-        f32 tmp2_ = (dVar11 + (i_zoom * (centerY - dVar11)));
-        
+        f32 tmp2_ = (dVar11 + (i_zoom * (centerY - dVar11)));  
+
         field_0xf0c[mRegionCursor] =
             ((tmp2 + (tmp3 * mZoom)) - mRegionMapSizeX[mRegionCursor] * mZoom * 0.5f) -
             mRegionMinMapX[mRegionCursor];
@@ -1005,6 +1012,11 @@ void dMenu_Fmap2DBack_c::allmap_move2(STControl* param_0) {
         f32 stickValue = param_0->getValueStick();
         if (stickValue >= spC) {
             s16 angle = param_0->getAngleStick();
+#ifdef TARGET_PC
+            if (dusk::getSettings().game.enableMirrorMode) {
+                angle = -angle;
+            }
+#endif
             f32 local_68 = (mTexMaxX - mTexMinX);
             f32 zoomRate = local_68 / getAllMapZoomRate();
             f32 sp24;
@@ -1046,11 +1058,6 @@ void dMenu_Fmap2DBack_c::allmap_move2(STControl* param_0) {
     calcAllMapPos2D((mArrowPos3DX + control_xpos) - mStageTransX,
                     (mArrowPos3DZ + control_ypos) - mStageTransZ, &sp14, &sp10);
 
-#if TARGET_PC
-    if (dusk::getSettings().game.enableMirrorMode) {
-        sp14 = getMirrorPosX(sp14, 0.0f);
-    }
-#endif
 
     mSelectRegion = 0xff;
     for (int i = 7; i >= 0; i--) {
@@ -1907,6 +1914,11 @@ void dMenu_Fmap2DBack_c::regionMapMove(STControl* i_stick) {
         f32 stick_value = i_stick->getValueStick();
         if (stick_value >= slow_bound) {
             s16 angle = i_stick->getAngleStick();
+            #ifdef TARGET_PC
+            if (dusk::getSettings().game.enableMirrorMode) {
+                angle = -angle;
+            }
+            #endif
             f32 local_68 = mTexMaxX - mTexMinX;
             f32 spot_zoom = getSpotMapZoomRate();
             f32 region_zoom = getRegionMapZoomRate(mRegionCursor);
@@ -1946,11 +1958,6 @@ void dMenu_Fmap2DBack_c::regionMapMove(STControl* i_stick) {
     calcAllMapPos2D(mArrowPos3DX + control_xpos - mStageTransX,
                     mArrowPos3DZ + control_ypos - mStageTransZ, &pos_x, &pos_y);
 
-#if TARGET_PC
-    if (dusk::getSettings().game.enableMirrorMode) {
-        pos_x = getMirrorPosX(pos_x, 0.0f);
-    }
-#endif
 
     mSelectRegion = 0xff;
     int region = mRegionCursor;

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -427,13 +427,14 @@ void dMenu_Fmap2DBack_c::draw() {
 
         mpPointParent->setAlphaRate(mArrowAlpha * mSpotTextureFadeAlpha);
 
-        #ifdef TARGET_PC
+        f32 drawX = mArrowPos2DX + mTransX;
+#ifdef TARGET_PC
         if (dusk::getSettings().game.enableMirrorMode) {
-            mArrowPos2DX = getMirrorPosX(mArrowPos2DX,0.0f);
+            drawX = getMirrorPosX(drawX, 0.0f);
         }
-        #endif
+#endif
 
-        mpPointParent->translate(mArrowPos2DX + mTransX, mArrowPos2DY + mTransZ);
+        mpPointParent->translate(drawX, mArrowPos2DY + mTransZ);
         mpPointScreen->draw(0.0f, 0.0f, grafPort);
     }
 
@@ -751,7 +752,7 @@ void dMenu_Fmap2DBack_c::zoomMapCalc(f32 i_zoom) {
         f32 tmp = (mRegionMinMapY[mRegionCursor] + mRegionMapSizeY[mRegionCursor] * 0.5f) - dVar11;
 
         f32 tmp2 = (dVar12 + (i_zoom * (centerX - dVar12)));
-        f32 tmp2_ = (dVar11 + (i_zoom * (centerY - dVar11)));  
+        f32 tmp2_ = (dVar11 + (i_zoom * (centerY - dVar11)));
 
         field_0xf0c[mRegionCursor] =
             ((tmp2 + (tmp3 * mZoom)) - mRegionMapSizeX[mRegionCursor] * mZoom * 0.5f) -

--- a/src/dusk/touch_camera.cpp
+++ b/src/dusk/touch_camera.cpp
@@ -7,6 +7,9 @@ float s_pitch_dp = 0.0f;
 }  // namespace
 
 void add_delta(float yaw_dp, float pitch_dp) noexcept {
+    if (getSettings().game.enableMirrorMode) {
+        yaw_dp *= -1.0;
+    }
     s_yaw_dp += yaw_dp;
     s_pitch_dp += pitch_dp;
 }


### PR DESCRIPTION
- Invert the x-axis for touch controls on mirror mode
- Invert the control-stick for free-cam mode on mirror mode
- Fix issues with the map cursor on mirror mode by inverting the map cursor controls and mirroring the cursor position when it is drawn

Fixes #979, Fixes #2086