### PR TITLE
Hide cursor when "enable menu pointer" is disabled

### DIFF
--- a/src/dusk/mouse.cpp
+++ b/src/dusk/mouse.cpp
@@ -119,7 +119,7 @@ void update_cursor_visibility(SDL_Window* window, bool captured) {
         return;
     }
 
-    if (captured) {
+    if (captured || (!getSettings().game.enableMenuPointer.getValue() && !ui::any_document_visible())) {
         s_idle_frames = 0;
         set_cursor_visible(false);
         return;


### PR DESCRIPTION
This adds an additional check when setting cursor visibility. The cursor will hide if "enable menu pointer" is disabled and there is no Dusklight UI visible.

This is helpful on devices like the Steam Deck where gyro input must be read as mouse input (#2091).