### PR TITLE
Mirror Mode Map Fixes

### DIFF
--- a/src/d/d_map.cpp
+++ b/src/d/d_map.cpp
@@ -1640,7 +1640,7 @@ void dMap_c::_move(f32 i_centerX, f32 i_centerZ, int i_roomNo, f32 param_3) {
 
         mCenterX += IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -mPackX :) mPackX;
         mCenterZ -= mPackZ;
-        mCenterX += field_0x64;
+        mCenterX += IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -field_0x64 : ) field_0x64;
         mCenterZ += mPackPlusZ;
     }
 
@@ -1649,6 +1649,8 @@ void dMap_c::_move(f32 i_centerX, f32 i_centerZ, int i_roomNo, f32 param_3) {
     {
 #if DEBUG
         field_0x64 = 33830.0f;
+#elif TARGET_PC
+        field_0x64 = dusk::getSettings().game.enableMirrorMode ? 33830.0f : 0.0f;
 #else
         field_0x64 = 0.0f;
 #endif
@@ -1657,6 +1659,9 @@ void dMap_c::_move(f32 i_centerX, f32 i_centerZ, int i_roomNo, f32 param_3) {
         f32 temp = (field_0x58 * (f32)(field_0x74 + 4)) * 0.5f;
 #if DEBUG
         mRightEdgePlus = -(((dMpath_c::getMinZ() - (-127103.67f)) - temp) / field_0x58);
+
+#elif TARGET_PC
+        mRightEdgePlus = dusk::getSettings().game.enableMirrorMode ? -(((dMpath_c::getMinX() - (-127103.67f)) - temp) / field_0x58) : 0.0f;
 #else
         mRightEdgePlus = 0.0f;
 #endif

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -960,6 +960,15 @@ void dMenu_DmapBg_c::draw() {
         mpBackTexture->setAlpha(dVar17 * (field_0xdbc * field_0xd9c));
 
         f32 local_28c = mpBackTexture->getBounds().i.x;
+
+        #if TARGET_PC
+            if(dusk::getSettings().game.enableMirrorMode) {
+                CPaneMgr mgr;
+                Vec local_94 = mgr.getGlobalVtxCenter(mMapPane, true, 0);
+                local_28c = (local_94.x * 2.0f) - (local_28c + 0.5f * mpBackTexture->getWidth()) - 0.5f * mpBackTexture->getWidth();
+            }
+        #endif
+
         mpBackTexture->setBlackWhite(color_black, color_white);
         mpBackTexture->draw(local_28c, field_0xd94 + mpBackTexture->getBounds().i.y, mpBackTexture->getWidth(),
                             mpBackTexture->getHeight(),
@@ -1242,6 +1251,12 @@ void dMenu_Dmap_c::screenInit() {
             } else {
                 mpDrawBg->mFloorScreen->search('wolf')->hide();
                 mpDrawBg->mFloorScreen->search('rink')->show();
+
+                #if TARGET_PC
+                    if(dusk::getSettings().game.enableMirrorMode) {
+                        ((J2DPicture*)mpDrawBg->mFloorScreen->search('rink'))->setMirror(J2DMirror_X);
+                    }
+                #endif
             }
         }
     }
@@ -1285,7 +1300,14 @@ void dMenu_Dmap_c::screenInit() {
     field_0x7c[1] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('con_n'), 3, NULL);
     field_0x7c[2] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('key_n'), 3, NULL);
     field_0x88[0] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('map000'), 3, NULL);
+    #if TARGET_PC
+        if(dusk::getSettings().game.enableMirrorMode) {
+            ((J2DPicture*)field_0x88[0]->getPanePtr())->setMirror(J2DMirror_X);
+        }
+    #endif
     field_0x88[1] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('con000'), 3, NULL);
+
+    ((J2DPicture*)field_0x88[0]->getPanePtr())->setMirror(J2DMirror_X);
     
     if (dStage_stagInfo_GetSaveTbl(dComIfGp_getStageStagInfo()) == dStage_SaveTbl_LV2) {
         field_0x88[2] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('i_key_n'), 3, NULL);
@@ -1981,7 +2003,7 @@ void dMenu_Dmap_c::mapControl() {
         f32 temp_f28 = (var_f29 / 100.0f) * var_f31;
         f32 sp18 = temp_f28 * cM_ssin(stick_angle);
         f32 sp14 = temp_f28 * cM_scos(stick_angle);
-        mMapCtrl->setPlusZoomCenterX(sp18);
+        mMapCtrl->setPlusZoomCenterX(IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -sp18 :) sp18);
         mMapCtrl->setPlusZoomCenterZ(sp14);
     }
 

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -914,6 +914,20 @@ void dMenu_DmapBg_c::dMapBgWide() {
 void dMenu_DmapBg_c::draw() {
     #if TARGET_PC
     dMapBgWide();
+
+    static bool prevMirror = false; // default state of panes is not mirrored
+    if(prevMirror != dusk::getSettings().game.enableMirrorMode) {
+        if(dusk::getSettings().game.enableMirrorMode) {
+            static_cast<J2DPicture*>(mFloorScreen->search(MULTI_CHAR('rink')))->setMirror(J2DMirror_X);
+            static_cast<J2DPicture*>(mBaseScreen->search(MULTI_CHAR('map000')))->setMirror(J2DMirror_X);
+        }
+        else {
+            static_cast<J2DPicture*>(mFloorScreen->search(MULTI_CHAR('rink')))->setMirror(MIRROR0);
+            static_cast<J2DPicture*>(mBaseScreen->search(MULTI_CHAR('map000')))->setMirror(MIRROR0);
+        }
+
+        prevMirror = dusk::getSettings().game.enableMirrorMode;
+    }
     #endif
 
     u32 scissor_left;
@@ -1251,12 +1265,6 @@ void dMenu_Dmap_c::screenInit() {
             } else {
                 mpDrawBg->mFloorScreen->search('wolf')->hide();
                 mpDrawBg->mFloorScreen->search('rink')->show();
-
-                #if TARGET_PC
-                    if(dusk::getSettings().game.enableMirrorMode) {
-                        ((J2DPicture*)mpDrawBg->mFloorScreen->search('rink'))->setMirror(J2DMirror_X);
-                    }
-                #endif
             }
         }
     }
@@ -1300,11 +1308,6 @@ void dMenu_Dmap_c::screenInit() {
     field_0x7c[1] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('con_n'), 3, NULL);
     field_0x7c[2] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('key_n'), 3, NULL);
     field_0x88[0] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('map000'), 3, NULL);
-    #if TARGET_PC
-        if(dusk::getSettings().game.enableMirrorMode) {
-            ((J2DPicture*)field_0x88[0]->getPanePtr())->setMirror(J2DMirror_X);
-        }
-    #endif
     field_0x88[1] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('con000'), 3, NULL);
     
     if (dStage_stagInfo_GetSaveTbl(dComIfGp_getStageStagInfo()) == dStage_SaveTbl_LV2) {

--- a/src/d/d_menu_dmap.cpp
+++ b/src/d/d_menu_dmap.cpp
@@ -1306,8 +1306,6 @@ void dMenu_Dmap_c::screenInit() {
         }
     #endif
     field_0x88[1] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('con000'), 3, NULL);
-
-    ((J2DPicture*)field_0x88[0]->getPanePtr())->setMirror(J2DMirror_X);
     
     if (dStage_stagInfo_GetSaveTbl(dComIfGp_getStageStagInfo()) == dStage_SaveTbl_LV2) {
         field_0x88[2] = JKR_NEW CPaneMgr(mpDrawBg->mBaseScreen, MULTI_CHAR('i_key_n'), 3, NULL);

--- a/src/d/d_menu_dmap_map.cpp
+++ b/src/d/d_menu_dmap_map.cpp
@@ -359,14 +359,7 @@ f32 dMenu_StageMapCtrl_c::getPixelStageSizeZ() const {
 
 f32 dMenu_StageMapCtrl_c::getPixelCenterX() const {
     f32 var_f31 = dMpath_c::getCenterX();
-    #if TARGET_PC
-    if (dusk::getSettings().game.enableMirrorMode) {
-        return (1.0f / field_0xbc) * (field_0x9c + var_f31);
-    }
-    else return (1.0f / field_0xbc) * (field_0x9c - var_f31);
-    #else
     return (1.0f / field_0xbc) * (field_0x9c - var_f31);
-    #endif
 }
 
 f32 dMenu_StageMapCtrl_c::getPixelCenterZ() const {
@@ -425,18 +418,7 @@ inline static f32 rightModeCnvPos(f32 param_0) {
 void dMenu_StageMapCtrl_c::cnvPosTo2Dpos(f32 param_0, f32 param_1, f32* param_2,
                                          f32* param_3) const {
     if (param_2 != NULL) {
-        #if TARGET_PC
-        if (dusk::getSettings().game.enableMirrorMode) {
-            *param_2 =
-                (0.5f * field_0x94) + rightModeCnvPos((1.0f / field_0xbc) * (field_0x9c + param_0));
-        } else {
-            *param_2 =
-                (0.5f * field_0x94) + rightModeCnvPos((1.0f / field_0xbc) * (param_0 - field_0x9c));
-        }
-        #else
         *param_2 = (0.5f * field_0x94) + rightModeCnvPos((1.0f / field_0xbc) * (param_0 - field_0x9c));
-        #endif
-
     }
 
     if (param_3 != NULL) {
@@ -933,8 +915,7 @@ void dMenu_StageMapCtrl_c::move() {
 
 void dMenu_DmapMapCtrl_c::draw() {
     if (field_0xef != 0) {
-        setPos(field_0xeb, field_0xec,
-            IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -field_0x9c :) field_0x9c,
+        setPos(field_0xeb, field_0xec, field_0x9c,
             field_0xa0, field_0xbc, true, field_0xd8);
     }
 }

--- a/src/d/d_menu_fmap.cpp
+++ b/src/d/d_menu_fmap.cpp
@@ -931,17 +931,8 @@ void dMenu_Fmap_c::region_map_proc() {
         mpDraw2DBack->regionMapMove(mpStick);
         int stage_no, room_no;
 
-#if TARGET_PC
-        f32 arrow_pos_x = mpDraw2DBack->getArrowPos2DX();
-        if (dusk::getSettings().game.enableMirrorMode) {
-            arrow_pos_x = mpDraw2DBack->getMirrorPosX(arrow_pos_x, 0.0f);
-        }
-
-        f32 pos_x = arrow_pos_x - mDoGph_gInf_c::getMinXF() - mDoGph_gInf_c::getWidthF() * 0.5f;
-#else
         f32 pos_x = mpDraw2DBack->getArrowPos2DX() - mDoGph_gInf_c::getMinXF()
                                                     - mDoGph_gInf_c::getWidthF() * 0.5f;
-#endif
         f32 pos_y = mpDraw2DBack->getArrowPos2DY() - mDoGph_gInf_c::getHeightF() * 0.5f;
 
         mpMenuFmapMap->getPointStagePathInnerNo(getNowFmapRegionData(), pos_x, pos_y,
@@ -2486,12 +2477,6 @@ void dMenu_Fmap_c::portalWarpMapMove(STControl* i_stick) {
     f32 arrow_y = mpDraw2DBack->getArrowPos2DY();
     u8 uVar6 = 0xff;
 
-#if TARGET_PC
-    if (dusk::getSettings().game.enableMirrorMode) {
-        arrow_x = mpDraw2DBack->getMirrorPosX(arrow_x, 0.0f);
-    }
-#endif
-
 
     for (int i = 0; i < portal_dat->mCount; i++) {
         if (portals[i].mRegionNo == mpDraw2DBack->getRegionCursor() + 1
@@ -2561,6 +2546,11 @@ void dMenu_Fmap_c::drawIcon(f32 param_0, bool param_1) {
     if (mProcess == PROC_PORTAL_DEMO1) {
         is_portal_demo1 = 1;
     }
+    #if TARGET_PC
+    if(dusk::getSettings().game.enableMirrorMode) {
+        angle = 0x10000 - angle;
+    }
+    #endif
     mpDraw2DBack->setIcon2DPos(0x11, stage_name, pos.x, pos.z, cM_sht2d(angle),
                                is_portal_demo1, param_1);
     
@@ -2649,6 +2639,11 @@ void dMenu_Fmap_c::drawPlayEnterIcon() {
             angle = dComIfGs_getPlayerFieldLastStayAngleY();
             SAFE_STRCPY(stage_name, dComIfGs_getPlayerFieldLastStayName());
         }
+        #if TARGET_PC
+        if(dusk::getSettings().game.enableMirrorMode) {
+            angle = 0x10000 - angle;
+        }
+        #endif
         mpDraw2DBack->setIcon2DPos(0x15, stage_name, pos.x, pos.z, cM_sht2d(angle), 0, false);
     }
 }

--- a/src/d/d_menu_fmap2D.cpp
+++ b/src/d/d_menu_fmap2D.cpp
@@ -1013,11 +1013,6 @@ void dMenu_Fmap2DBack_c::allmap_move2(STControl* param_0) {
         f32 stickValue = param_0->getValueStick();
         if (stickValue >= spC) {
             s16 angle = param_0->getAngleStick();
-#ifdef TARGET_PC
-            if (dusk::getSettings().game.enableMirrorMode) {
-                angle = -angle;
-            }
-#endif
             f32 local_68 = (mTexMaxX - mTexMinX);
             f32 zoomRate = local_68 / getAllMapZoomRate();
             f32 sp24;
@@ -1031,6 +1026,11 @@ void dMenu_Fmap2DBack_c::allmap_move2(STControl* param_0) {
             f32 delta_y = speed * cM_ssin(angle);
             f32 delta_x = speed * cM_scos(angle);
 
+#ifdef TARGET_PC
+            if (dusk::getSettings().game.enableMirrorMode) {
+                delta_y = -delta_y;
+            }
+#endif
             control_xpos = control_xpos + delta_y;
             control_ypos = control_ypos + delta_x;
         }
@@ -1473,6 +1473,12 @@ void dMenu_Fmap2DBack_c::worldGridDraw() {
     f32 dVar8 = -mStageTransZ;
     calcAllMapPos2D(dVar9, dVar8, &local_74, &local_78);
 
+    #if TARGET_PC
+    if(dusk::getSettings().game.enableMirrorMode) {
+        local_74 = getMirrorPosX(local_74, 0.0f);
+    }
+    #endif
+
     J2DDrawLine(local_74, mDoGph_gInf_c::getMinYF(), local_74,
                 mDoGph_gInf_c::getMinYF() + mDoGph_gInf_c::getHeightF(),
                 JUtility::TColor(255, 255, 255, 255), 6);
@@ -1481,6 +1487,11 @@ void dMenu_Fmap2DBack_c::worldGridDraw() {
     while (true) {
         calcAllMapPos2D(xPos, dVar8, &local_74, &local_78);
         if (local_74 >= getMapScissorAreaLX()) {
+            #if TARGET_PC
+            if(dusk::getSettings().game.enableMirrorMode) {
+                local_74 = getMirrorPosX(local_74, 0.0f);
+            }
+            #endif
             J2DDrawLine(local_74, mDoGph_gInf_c::getMinYF(), local_74,
                         mDoGph_gInf_c::getMinYF() + mDoGph_gInf_c::getHeightF(),
                         JUtility::TColor(255, 255, 255, 255), 6);
@@ -1542,6 +1553,12 @@ void dMenu_Fmap2DBack_c::regionGridDraw() {
     f32 dVar8 = mRegionOriginZ[mRegionCursor] - mStageTransZ;
     calcAllMapPos2D(dVar9, dVar8, &local_74, &local_78);
 
+    #if TARGET_PC
+    if(dusk::getSettings().game.enableMirrorMode) {
+        local_74 = getMirrorPosX(local_74, 0.0f);
+    }
+    #endif
+
     J2DDrawLine(local_74, mDoGph_gInf_c::getMinYF(), local_74,
                 mDoGph_gInf_c::getMinYF() + mDoGph_gInf_c::getHeightF(),
                 JUtility::TColor(180, 0, 0, 255), 6);
@@ -1550,6 +1567,12 @@ void dMenu_Fmap2DBack_c::regionGridDraw() {
     while (true) {
         calcAllMapPos2D(xPos, dVar8, &local_74, &local_78);
         if (local_74 >= getMapScissorAreaLX()) {
+            #if TARGET_PC
+            if(dusk::getSettings().game.enableMirrorMode) {
+                local_74 = getMirrorPosX(local_74, 0.0f);
+            }
+            #endif
+
             J2DDrawLine(local_74, mDoGph_gInf_c::getMinYF(), local_74,
                         mDoGph_gInf_c::getMinYF() + mDoGph_gInf_c::getHeightF(),
                         JUtility::TColor(180, 0, 0, 255), 6);
@@ -1612,6 +1635,12 @@ void dMenu_Fmap2DBack_c::worldOriginDraw() {
     f32 local_44, local_48;
     calcAllMapPos2D(-mStageTransX, -mStageTransZ, &local_44, &local_48);
 
+    #if TARGET_PC
+    if(dusk::getSettings().game.enableMirrorMode) {
+        local_44 = getMirrorPosX(local_44, 0.0f);
+    }
+    #endif
+
     J2DDrawLine(mDoGph_gInf_c::getMinXF(), local_48 - local_44 + mDoGph_gInf_c::getMinXF(),
                 mDoGph_gInf_c::getMinXF() + mDoGph_gInf_c::getWidthF(),
                 local_48 - local_44 + (mDoGph_gInf_c::getMinXF() + mDoGph_gInf_c::getWidthF()),
@@ -1646,6 +1675,13 @@ void dMenu_Fmap2DBack_c::scrollAreaDraw() {
         calcAllMapPos2D(x_min - mStageTransX, z_min - mStageTransZ, &local_4c, &local_50);
         calcAllMapPos2D(x_max - mStageTransX, z_max - mStageTransZ, &local_54, &local_58);
 
+        #if TARGET_PC
+        if(dusk::getSettings().game.enableMirrorMode) {
+            local_4c = getMirrorPosX(local_4c, 0.0f);
+            local_54 = getMirrorPosX(local_54, 0.0f);
+        }
+        #endif
+
         J2DDrawLine(local_4c, local_50, local_4c, local_58,
                     JUtility::TColor(255, 255, 255, 255), 6);
         J2DDrawLine(local_54, local_50, local_54, local_58,
@@ -1666,6 +1702,11 @@ void dMenu_Fmap2DBack_c::regionOriginDraw() {
         f32 center_x, center_y;
         calcAllMapPos2D(mRegionOriginX[i] - mStageTransX, mRegionOriginZ[i] - mStageTransZ,
                         &center_x, &center_y);
+        #if TARGET_PC
+        if(dusk::getSettings().game.enableMirrorMode) {
+            center_x = getMirrorPosX(center_x - 3.0f, 3.0f);
+        }
+        #endif
         J2DFillBox(center_x - 3.0f, center_y - 3.0f, 6.0f, 6.0f, JUtility::TColor(255, 0, 0, 255));
     }
 }
@@ -1683,6 +1724,11 @@ void dMenu_Fmap2DBack_c::stageOriginDraw() {
             f32 v1 = mRegionOriginX[mRegionCursor] + stage_data[i].mOffsetX - mStageTransX;
             f32 v2 = mRegionOriginZ[mRegionCursor] + stage_data[i].mOffsetZ - mStageTransZ;
             calcAllMapPos2D(v1, v2, &center_x, &center_y);
+            #if TARGET_PC
+            if(dusk::getSettings().game.enableMirrorMode) {
+                center_x = getMirrorPosX(center_x - 3.0f, 3.0f);
+            }
+            #endif
             J2DFillBox(center_x - 3.0f, center_y - 3.0f, 6.0f, 6.0f,
                        JUtility::TColor(0, 0, 255, 255));
         }
@@ -1915,11 +1961,6 @@ void dMenu_Fmap2DBack_c::regionMapMove(STControl* i_stick) {
         f32 stick_value = i_stick->getValueStick();
         if (stick_value >= slow_bound) {
             s16 angle = i_stick->getAngleStick();
-            #ifdef TARGET_PC
-            if (dusk::getSettings().game.enableMirrorMode) {
-                angle = -angle;
-            }
-            #endif
             f32 local_68 = mTexMaxX - mTexMinX;
             f32 spot_zoom = getSpotMapZoomRate();
             f32 region_zoom = getRegionMapZoomRate(mRegionCursor);
@@ -1934,7 +1975,7 @@ void dMenu_Fmap2DBack_c::regionMapMove(STControl* i_stick) {
             f32 speed = base_speed / 100.0f * local_78;
             f32 speed_y = speed * cM_ssin(angle);
             f32 speed_x = speed * cM_scos(angle);
-            control_xpos += speed_y;
+            control_xpos += IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -speed_y :) speed_y;
             control_ypos += speed_x;
         }
     }
@@ -1990,11 +2031,6 @@ void dMenu_Fmap2DBack_c::stageMapMove(STControl* i_stick, u8 param_1, bool param
     if (stick_value >= slow_bound && param_2 && field_0x1238 != 2) {
         bVar6 = true;
         s16 angle = i_stick->getAngleStick();
-#if TARGET_PC
-        if (dusk::getSettings().game.enableMirrorMode) {
-            angle = -angle;
-        }
-#endif
         f32 local_68 = mTexMaxX - mTexMinX;
         f32 spot_zoom = getSpotMapZoomRate();
         f32 region_zoom = getRegionMapZoomRate(mRegionCursor);
@@ -2009,7 +2045,7 @@ void dMenu_Fmap2DBack_c::stageMapMove(STControl* i_stick, u8 param_1, bool param
         f32 speed = base_speed / 100.0f * local_78;
         f32 speed_x = speed * cM_ssin(angle);
         f32 speed_z = speed * cM_scos(angle);
-        mStageTransX += speed_x;
+        mStageTransX += IF_DUSK(dusk::getSettings().game.enableMirrorMode ? -speed_x :) speed_x;
         mStageTransZ += speed_z;
     } else if (!param_2) {
         return;
@@ -2103,6 +2139,11 @@ void dMenu_Fmap2DBack_c::drawDebugStageArea() {
                 if (stage_no >= 0) {
                     f32 v = i + mDoGph_gInf_c::getMinXF();
                     f32 v2 = j;
+                    #if TARGET_PC
+                    if(dusk::getSettings().game.enableMirrorMode) {
+                        v = getMirrorPosX(v - 3.0f, 3.0f);
+                    }
+                    #endif
                     J2DFillBox(v - 3.0f, v2 - 3.0f, 6.0f, 6.0f, colors[stage_no % 6]);
                 }
             }
@@ -2138,6 +2179,11 @@ void dMenu_Fmap2DBack_c::drawDebugRegionArea() {
                     mRegionMapSizeX[region] * mZoom, mRegionMapSizeY[region] * mZoom,
                     mpAreaTex[region]->getTexture(0)->getTexInfo());
                 if (u) {
+                    #if TARGET_PC
+                    if(dusk::getSettings().game.enableMirrorMode) {
+                        pos_x = getMirrorPosX(pos_x - 3.0f, 3.0f);
+                    }
+                    #endif
                     J2DFillBox(pos_x - 3.0f, pos_y - 3.0f, 6.0f, 6.0f, colors[region]);
                     break;
                 }

--- a/src/d/d_menu_map_common.cpp
+++ b/src/d/d_menu_map_common.cpp
@@ -394,21 +394,8 @@ void dMenuMapCommon_c::drawIcon(f32 i_posX, f32 i_posY, f32 param_3, f32 param_4
                     icon_size_y *= _c7c;
                 }
 
-#if TARGET_PC
-                f32 rotation = mIconInfo[info_idx].rotation;
-                if (dusk::getSettings().game.enableMirrorMode &&
-                    (mIconInfo[info_idx].icon_no == ICON_LINK_e ||
-                     mIconInfo[info_idx].icon_no == ICON_LINK_ENTER_e))
-                {
-                    rotation = -rotation;
-                }
-
-                mPictures[mIconInfo[info_idx].icon_no]->rotate(icon_size_x / 2, icon_size_y / 2, ROTATE_Z,
-                                                               rotation);
-#else
                 mPictures[mIconInfo[info_idx].icon_no]->rotate(icon_size_x / 2, icon_size_y / 2, ROTATE_Z,
                                                         mIconInfo[info_idx].rotation);
-#endif
 
                 if (mIconInfo[info_idx].icon_no == ICON_LIGHT_DROP_e) {
                     mPictures[mIconInfo[info_idx].icon_no]->setAlpha((180.0f * _c80) / 255.0f);
@@ -423,9 +410,14 @@ void dMenuMapCommon_c::drawIcon(f32 i_posX, f32 i_posY, f32 param_3, f32 param_4
                 }
 
                 f32 pos_x = i_posX + (icon_pos_x - (icon_size_x / 2));
+                bool r4 = false;
                 #if TARGET_PC
                 if (dusk::getSettings().game.enableMirrorMode) {
                     pos_x = getMirrorCenterPosX(i_posX + (icon_pos_x - (icon_size_x / 2)), icon_size_x / 2);
+                }
+
+                if(mIconInfo[info_idx].icon_no == ICON_GOLD_WOLF_e) {
+                    r4 = true;
                 }
                 #endif
 
@@ -435,7 +427,7 @@ void dMenuMapCommon_c::drawIcon(f32 i_posX, f32 i_posY, f32 param_3, f32 param_4
                 if (mIconInfo[info_idx].icon_no == ICON_LIGHT_DROP_e) {
                     mLightDropPic->draw((pos_x + (icon_size_x / 2)) - (var_f29 / 2),
                                         ((icon_size_y / 2) + (i_posY + (icon_pos_y - icon_size_y / 2))) - (var_f28 / 2),
-                                        var_f29, var_f28, false, false, false);
+                                        var_f29, var_f28, r4, false, false);
                 }
             }
         }

--- a/src/d/d_msg_object.cpp
+++ b/src/d/d_msg_object.cpp
@@ -428,17 +428,6 @@ static void dummyStrings() {
 dMsgObject_HIO_c g_MsgObject_HIO_c;
 
 int dMsgObject_c::_execute() {
-// TODO: enabling wii message overrides fixes direction text, but gives wrong item control text
-/*#if TARGET_PC
-    if (dusk::getSettings().game.enableMirrorMode) {
-        // enable wii message index override
-        g_MsgObject_HIO_c.mMessageDisplay = 1;
-    } else if (!dusk::getSettings().game.enableMirrorMode && g_MsgObject_HIO_c.mMessageDisplay == 1) {
-        g_MsgObject_HIO_c.mMessageDisplay = 0;
-    }
-#endif*/
-
-
     field_0x4c7 = 0;
     if (mpTalkHeap != NULL) {
         field_0x148 = mDoExt_setCurrentHeap(mpTalkHeap);


### PR DESCRIPTION
Based on Wii decomp in https://github.com/zeldaret/tp/pull/3168

Fixes #2158
Supersedes #2172

~~I need to do more testing with the calls to `setMIrror` to make sure they update properly when the setting is changed/what their actual effect is, would hold off on merging until that is figured out.~~ The `setMirror` calls flip the icons for the dungeon map and Link (next to the floor number), should now be updating properly with 8e8dc305e6afb3006046756076c28dd1cea1c24e.