### PR TITLE
Add UI localization framework with Italian language

### DIFF
--- a/files.cmake
+++ b/files.cmake
@@ -1442,6 +1442,7 @@ set(DUSK_FILES
 		src/dusk/gamepad_color.cpp
 		src/dusk/autosave.cpp
         src/dusk/http/http.hpp
+        src/dusk/i18n.cpp
         src/dusk/io.cpp
         src/dusk/layout.cpp
         src/dusk/logging.cpp

--- a/include/dusk/i18n.h
+++ b/include/dusk/i18n.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string_view>
+
+/**
+ * Lightweight UI localization ("i18n") for Dusklight.
+ *
+ * Strings are keyed by their English source text (msgid), gettext-style. Wrap a
+ * user-facing UI literal in tr(...) and it will be translated into the language
+ * selected by the "ui.language" setting, falling back to the English source when
+ * no translation exists for the active language.
+ *
+ *     button->set_text(tr("Play"));
+ *
+ * The English source doubles as the key, so English builds are unaffected and
+ * adding a new string never requires touching existing translation tables.
+ */
+namespace dusk::i18n {
+
+/**
+ * \brief Translate an English source string into the active UI language.
+ *
+ * @param msgid A null-terminated English source string (used as the lookup key).
+ * @return The translation for the active UI language, or \p msgid itself when no
+ *         translation exists. The returned pointer is always null-terminated and
+ *         has static storage duration.
+ */
+const char* tr(const char* msgid) noexcept;
+
+}  // namespace dusk::i18n
+
+namespace dusk {
+// Bring tr() into the dusk namespace so it resolves unqualified from dusk::ui.
+using i18n::tr;
+}  // namespace dusk

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -34,6 +34,11 @@ enum class GameLanguage : u8 {
     Italian = OS_LANGUAGE_ITALIAN,
 };
 
+enum class UiLanguage : u8 {
+    English = 0,
+    Italian = 1,
+};
+
 enum class DiscVerificationState : u8 {
     Unknown = 0,
     Success,
@@ -89,6 +94,12 @@ template <>
 struct ConfigEnumRange<GameLanguage> {
     static constexpr auto min = GameLanguage::English;
     static constexpr auto max = GameLanguage::Italian;
+};
+
+template <>
+struct ConfigEnumRange<UiLanguage> {
+    static constexpr auto min = UiLanguage::English;
+    static constexpr auto max = UiLanguage::Italian;
 };
 
 template <>
@@ -293,6 +304,11 @@ struct UserSettings {
         ConfigVar<int> cardFileType;
         ConfigVar<bool> enableAdvancedSettings;
     } backend;
+
+    // Interface (Dusklight UI) settings
+    struct {
+        ConfigVar<UiLanguage> language;
+    } ui;
 
     // Arrays of size 4 for 4 ports
     struct {

--- a/src/dusk/config.cpp
+++ b/src/dusk/config.cpp
@@ -303,6 +303,7 @@ template class ConfigImpl<dusk::BloomMode>;
 template class ConfigImpl<dusk::DepthOfFieldMode>;
 template class ConfigImpl<dusk::DiscVerificationState>;
 template class ConfigImpl<dusk::GameLanguage>;
+template class ConfigImpl<dusk::UiLanguage>;
 
 template <>
 void ConfigImpl<FrameInterpMode>::loadFromJson(

--- a/src/dusk/i18n.cpp
+++ b/src/dusk/i18n.cpp
@@ -1,0 +1,49 @@
+#include "dusk/i18n.h"
+
+#include <absl/container/flat_hash_map.h>
+
+#include "dusk/settings.h"
+
+namespace dusk::i18n {
+namespace {
+
+using TranslationTable = absl::flat_hash_map<std::string_view, const char*>;
+
+// Italian translations, keyed by English source string.
+const TranslationTable& italian() {
+    static const TranslationTable kTable = {
+        {"Play", "Gioca"},
+        {"Select Disc Image", "Seleziona immagine disco"},
+        {"Settings", "Impostazioni"},
+        {"Quit", "Esci"},
+        {"Enable VSync", "Attiva VSync"},
+        {"Interface Language", "Lingua interfaccia"},
+    };
+    return kTable;
+}
+
+// Returns the translation table for the given language, or nullptr for English
+const TranslationTable* table_for(UiLanguage language) {
+    switch (language) {
+    case UiLanguage::Italian:
+        return &italian();
+    case UiLanguage::English:
+        break;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+const char* tr(const char* msgid) noexcept {
+    const TranslationTable* table = table_for(getSettings().ui.language.getValue());
+    if (table == nullptr) {
+        return msgid;
+    }
+    if (const auto it = table->find(std::string_view{msgid}); it != table->end()) {
+        return it->second;
+    }
+    return msgid;
+}
+
+}  // namespace dusk::i18n

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -167,6 +167,10 @@ UserSettings g_userSettings = {
         .enableAdvancedSettings {"backend.enableAdvancedSettings", false},
     },
 
+    .ui = {
+        .language {"ui.language", UiLanguage::English},
+    },
+
     // Not sure if there's a better way to declare this
     .actionBindings = {
         .firstPersonCamera {
@@ -350,6 +354,8 @@ void registerSettings() {
     Register(g_userSettings.backend.checkForUpdates);
     Register(g_userSettings.backend.cardFileType);
     Register(g_userSettings.backend.enableAdvancedSettings);
+
+    Register(g_userSettings.ui.language);
 
     Register(g_userSettings.actionBindings.firstPersonCamera[0]);
     Register(g_userSettings.actionBindings.firstPersonCamera[1]);

--- a/src/dusk/ui/menu_bar.cpp
+++ b/src/dusk/ui/menu_bar.cpp
@@ -9,6 +9,7 @@
 #include "aurora/rmlui.hpp"
 #include "dusk/speedrun.h"
 #include "dusk/livesplit.h"
+#include "dusk/i18n.h"
 #include "dusk/main.h"
 #include "dusk/settings.h"
 #include "editor.hpp"
@@ -50,7 +51,7 @@ MenuBar::MenuBar() : Document(kDocumentSource), mRoot(mDocument->GetElementById(
                                                       },
                                                   .autoSelect = false,
                                               });
-    mTabBar->add_tab("Settings", [this] { push(std::make_unique<SettingsWindow>()); });
+    mTabBar->add_tab(tr("Settings"), [this] { push(std::make_unique<SettingsWindow>()); });
 
     if (getSettings().backend.enableAdvancedSettings) {
         mTabBar->add_tab("Warp", [this] { push(std::make_unique<WarpWindow>()); });
@@ -96,7 +97,7 @@ MenuBar::MenuBar() : Document(kDocumentSource), mRoot(mDocument->GetElementById(
             .icon = "question-mark",
         }));
     });
-    mTabBar->add_tab("Quit", [this] {
+    mTabBar->add_tab(tr("Quit"), [this] {
         mTabBar->set_active_tab(-1);
         const auto dismiss = [](Modal& modal) { modal.pop(); };
         push(std::make_unique<Modal>(Modal::Props{

--- a/src/dusk/ui/prelaunch.cpp
+++ b/src/dusk/ui/prelaunch.cpp
@@ -3,6 +3,7 @@
 #include "dusk/config.hpp"
 #include "dusk/data.hpp"
 #include "dusk/file_select.hpp"
+#include "dusk/i18n.h"
 #include "dusk/iso_validate.hpp"
 #include "dusk/main.h"
 #include "dusk/settings.h"
@@ -692,7 +693,7 @@ Prelaunch::Prelaunch() : Document(kDocumentSource), mRoot(mDocument->GetElementB
         auto& state = prelaunch_state();
         const bool activeDiscLoaded = !state.activeDiscPath.empty();
         mMenuButtons.push_back(
-            std::make_unique<Button>(menuList, activeDiscLoaded ? "Play" : "Select Disc Image"));
+            std::make_unique<Button>(menuList, tr(activeDiscLoaded ? "Play" : "Select Disc Image")));
         mMenuButtons.back()->on_pressed([this] {
             if (prelaunch_state().activeDiscPath.empty()) {
                 open_iso_picker();
@@ -719,14 +720,14 @@ Prelaunch::Prelaunch() : Document(kDocumentSource), mRoot(mDocument->GetElementB
         });
         apply_intro_animation(mMenuButtons.back()->root(), "delay-1");
 
-        mMenuButtons.push_back(std::make_unique<Button>(menuList, "Settings"));
+        mMenuButtons.push_back(std::make_unique<Button>(menuList, tr("Settings")));
         mMenuButtons.back()->on_pressed([this] {
             mRestartSuppressed = false;
             push(std::make_unique<SettingsWindow>(true));
         });
         apply_intro_animation(mMenuButtons.back()->root(), "delay-2");
 
-        mMenuButtons.push_back(std::make_unique<Button>(menuList, "Quit"));
+        mMenuButtons.push_back(std::make_unique<Button>(menuList, tr("Quit")));
         mMenuButtons.back()->on_pressed([] { IsRunning = false; });
         apply_intro_animation(mMenuButtons.back()->root(), "delay-3");
     }
@@ -846,7 +847,7 @@ void Prelaunch::update() {
     }
 
     if (!mMenuButtons.empty()) {
-        mMenuButtons[0]->set_text(activeDiscLoaded ? "Play" : "Select Disc Image");
+        mMenuButtons[0]->set_text(tr(activeDiscLoaded ? "Play" : "Select Disc Image"));
     }
 
     const auto discStatusLabel = mDiscStatus->GetElementById("disc-status-label");

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -9,6 +9,7 @@
 #include "dusk/android_frame_rate.hpp"
 #include "dusk/config.hpp"
 #include "dusk/hotkeys.h"
+#include "dusk/i18n.h"
 #include "dusk/data.hpp"
 #include "dusk/file_select.hpp"
 #include "dusk/imgui/ImGuiEngine.hpp"
@@ -57,6 +58,13 @@ constexpr std::array kLanguageNames = {
     "French",
     "Spanish",
     "Italian",
+};
+
+// Language names for the UI. Order must match the UiLanguage enum.
+// Names are shown in their own language.
+constexpr std::array kUiLanguageNames = {
+    "English",
+    "Italiano",
 };
 
 constexpr std::array kCardFileTypes = {
@@ -768,7 +776,7 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
             rightPane, [](Pane& pane) { pane.clear(); });
         config_bool_select(leftPane, rightPane, getSettings().video.enableVsync,
             {
-                .key = "Enable VSync",
+                .key = tr("Enable VSync"),
                 .helpText = "Synchronizes the frame rate to your monitor's refresh rate.",
                 .onChange = [](bool value) { aurora_enable_vsync(value); },
             });
@@ -1442,6 +1450,41 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
         auto& rightPane = add_child<Pane>(content, Pane::Type::Uncontrolled);
 
         leftPane.add_section("Dusklight");
+        leftPane.register_control(
+            leftPane.add_select_button({
+                .key = tr("Interface Language"),
+                .getValue =
+                    [] {
+                        const auto idx = static_cast<u8>(getSettings().ui.language.getValue());
+                        return Rml::String{kUiLanguageNames[idx]};
+                    },
+                .isModified =
+                    [] {
+                        const auto& lang = getSettings().ui.language;
+                        return lang.getValue() != lang.getDefaultValue();
+                    },
+            }),
+            rightPane, [this](Pane& pane) {
+                for (int i = 0; i < static_cast<int>(kUiLanguageNames.size()); i++) {
+                    pane.add_button({
+                                        .text = kUiLanguageNames[i],
+                                        .isSelected =
+                                            [i] {
+                                                return getSettings().ui.language.getValue() ==
+                                                       static_cast<UiLanguage>(i);
+                                            },
+                                    })
+                        .on_pressed([this, i] {
+                            mDoAud_seStartMenu(kSoundItemChange);
+                            getSettings().ui.language.setValue(static_cast<UiLanguage>(i));
+                            config::Save();
+                            mPendingLanguageRefresh = true;
+                        });
+                }
+                pane.add_rml(
+                    "<br/>Changes the language of the Dusklight interface. Reopen the menu to "
+                    "translate everything.");
+            });
 #if DUSK_CAN_OPEN_DATA_FOLDER
         leftPane.register_control(
             leftPane.add_button("Open Data Folder").on_pressed([] {
@@ -1645,6 +1688,11 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
 void SettingsWindow::update() {
     if (mPrelaunch && top_document() == this) {
         try_push_verification_modal(*this);
+    }
+
+    if (mPendingLanguageRefresh) {
+        mPendingLanguageRefresh = false;
+        refresh_active_tab();
     }
 
     Window::update();

--- a/src/dusk/ui/settings.hpp
+++ b/src/dusk/ui/settings.hpp
@@ -12,6 +12,8 @@ public:
 
 protected:
     bool mPrelaunch;
+    // set when the UI language changes
+    bool mPendingLanguageRefresh = false;
 };
 
 }  // namespace dusk::ui


### PR DESCRIPTION
Adds a lightweight localization (i18n) framework for the RmlUi interface and wires up Italian as the first translation.

`dusk::tr()` looks up a string by its English source text and returns the translation for the active UI language, falling back to the English source when no entry exists. English builds are therefore unaffected, and adding a new string never requires touching existing translation tables.

## Changes

- New `dusk::i18n` module (`include/dusk/i18n.h`, `src/dusk/i18n.cpp`) with an Italian translation table keyed by English source strings.
- New `ui.language` setting (`UiLanguage` enum), independent from `game.language` (which selects the game's own text and is limited by the disc region). This lets the interface be Italian even on a US disc.
- "Interface Language" selector in **Settings → Interface**, with a deferred live refresh: the active tab is rebuilt in `SettingsWindow::update()` rather than synchronously inside the button callback, since that control lives in the tab content being torn down.
- First strings wrapped in `tr()`: Play, Select Disc Image, Settings, Quit, Enable VSync, Interface Language.
