### PR TITLE
Add deltatime to d_kankyo bloom/fog transitions

### DIFF
--- a/src/d/d_kankyo.cpp
+++ b/src/d/d_kankyo.cpp
@@ -37,6 +37,7 @@
 #include "dusk/settings.h"
 #include "dusk/frame_interpolation.h"
 #include "dusk/game_clock.h"
+static f32 timeScale = 1.0f;
 #endif
 
 static void GxXFog_set();
@@ -1799,6 +1800,9 @@ void dScnKy_env_light_c::setLight_palno_get(u8* prev_envr_id_p, u8* next_envr_id
     u8 psel_idx = 0;
     int i;
     int sp14 = 0;
+#if TARGET_PC
+    const f32 timeScale = (pattern_ratio_p == &g_env_light.pat_ratio) ? ::timeScale : 1.0f;
+#endif
 
     if (*init_timer_p != 0) {
         (*init_timer_p)++;
@@ -2132,14 +2136,22 @@ void dScnKy_env_light_c::setLight_palno_get(u8* prev_envr_id_p, u8* next_envr_id
 
             if (g_env_light.mColPatMode == 0) {
                 if (pselect_p->change_rate > 0.0f) {
+#if TARGET_PC
+                    *pattern_ratio_p += timeScale * ((1.0f / 30) / pselect_p->change_rate);
+#else
                     *pattern_ratio_p += (1.0f / 30) / pselect_p->change_rate;
+#endif
                 }
 
                 // pattern change rate is faster in hyrule field
                 if (strcmp(dComIfGp_getStartStageName(), "F_SP121") == 0 &&
                     *prev_pat_p == *next_pat_p)
                 {
+#if TARGET_PC
+                    *pattern_ratio_p += timeScale * (1.0f / 15);
+#else
                     *pattern_ratio_p += (1.0f / 15);
+#endif
                 }
 
                 if (*pattern_ratio_p >= 1.0f) {
@@ -2332,6 +2344,10 @@ void dScnKy_env_light_c::setLight() {
         u8 next_pal_start_id;
         u8 prev_pal_end_id;
         u8 next_pal_end_id;
+#if TARGET_PC
+        const f32 deltaTime = dusk::game_clock::consume_interval(this);
+        timeScale = deltaTime / dusk::game_clock::period_for_original_frames(1.0f);
+#endif
         setLight_palno_get(&g_env_light.PrevCol, &g_env_light.UseCol, &g_env_light.wether_pat0,
                            &g_env_light.wether_pat1, &prev_pal_start_id, &prev_pal_end_id,
                            &next_pal_start_id, &next_pal_end_id, &color_ratio, &start_pat_pal_id,
@@ -2517,8 +2533,6 @@ void dScnKy_env_light_c::setLight() {
                 f32 sin = cM_ssin(S_fuwan_sin);
 
                 #if TARGET_PC
-                    const f32 deltaTime = dusk::game_clock::consume_interval(this);
-                    const f32 timeScale = deltaTime / dusk::game_clock::period_for_original_frames(1.0f);
                     S_fuwan_sin += (s16)((cM_rndF(2000.0f) + 500) * timeScale);
                 #else
                     S_fuwan_sin += (s16)cM_rndF(2000.0f) + 500;


### PR DESCRIPTION
Expands on the deltatime solution to resolve bloom oscillation speed initially introduced by https://github.com/TwilitRealm/dusklight/pull/957 to also apply to the bloom/fog transition that occurs when moving between areas, so that it's no longer sped up when playing at higher than 30FPS.

Closes https://github.com/TwilitRealm/dusklight/issues/2144