### PR TITLE
HUD scaling fixes

### DIFF
--- a/src/d/d_meter2.cpp
+++ b/src/d/d_meter2.cpp
@@ -27,6 +27,15 @@
 #if TARGET_PC
 #include "dusk/memory.h"
 #include "dusk/settings.h"
+
+namespace {
+
+// Reads the user HUD scale setting, clamped to a safe range.
+f32 dGetUserHudScale() {
+    return std::clamp(dusk::getSettings().game.hudScale.getValue(), 0.5f, 2.0f);
+}
+
+}  // namespace
 #endif
 
 int dMeter2_c::_create() {
@@ -669,9 +678,7 @@ void dMeter2_c::moveLife() {
     }
 
 #if TARGET_PC
-    const f32 lifeGaugeScale =
-        g_drawHIO.mLifeParentScale *
-        std::clamp(dusk::getSettings().game.hudScale.getValue(), 0.5f, 2.0f);
+    const f32 lifeGaugeScale = g_drawHIO.mLifeParentScale * dGetUserHudScale();
 #else
     const f32 lifeGaugeScale = g_drawHIO.mLifeParentScale;
 #endif
@@ -1108,8 +1115,13 @@ void dMeter2_c::moveRupee() {
         }
     }
 
-    if (mRupeeKeyScale != g_drawHIO.mRupeeKeyScale) {
-        mRupeeKeyScale = g_drawHIO.mRupeeKeyScale;
+#if TARGET_PC
+    const f32 rupeeKeyScale = g_drawHIO.mRupeeKeyScale * dGetUserHudScale();
+#else
+    const f32 rupeeKeyScale = g_drawHIO.mRupeeKeyScale;
+#endif
+    if (mRupeeKeyScale != rupeeKeyScale) {
+        mRupeeKeyScale = rupeeKeyScale;
         draw_rupee = true;
     }
 
@@ -1207,8 +1219,13 @@ void dMeter2_c::moveKey() {
         }
     }
 
-    if (mKeyScale != g_drawHIO.mKeyScale) {
-        mKeyScale = g_drawHIO.mKeyScale;
+#if TARGET_PC
+    const f32 keyScale = g_drawHIO.mKeyScale * dGetUserHudScale();
+#else
+    const f32 keyScale = g_drawHIO.mKeyScale;
+#endif
+    if (mKeyScale != keyScale) {
+        mKeyScale = keyScale;
         draw_key = true;
     }
 
@@ -2139,8 +2156,13 @@ void dMeter2_c::moveButtonCross() {
         draw_cross = true;
     }
 
-    if (mButtonCrossScale != g_drawHIO.mButtonCrossScale) {
-        mButtonCrossScale = g_drawHIO.mButtonCrossScale;
+#if TARGET_PC
+    const f32 buttonCrossScale = g_drawHIO.mButtonCrossScale * dGetUserHudScale();
+#else
+    const f32 buttonCrossScale = g_drawHIO.mButtonCrossScale;
+#endif
+    if (mButtonCrossScale != buttonCrossScale) {
+        mButtonCrossScale = buttonCrossScale;
         draw_cross = true;
     }
 

--- a/src/d/d_meter2_draw.cpp
+++ b/src/d/d_meter2_draw.cpp
@@ -57,6 +57,7 @@ void dAnchorHudScale(CPaneMgr* i_pane, HudCorner i_corner, f32* io_x, f32* io_y,
 
 }  // namespace
 #endif
+
 dMeter2Draw_c::dMeter2Draw_c(JKRExpHeap* mp_heap) {
     OS_REPORT("enter dMeter2Draw_c::dMeter2Draw_c(JKRExpHeap *mp_heap)\n");
 

--- a/src/d/d_meter2_draw.cpp
+++ b/src/d/d_meter2_draw.cpp
@@ -2782,7 +2782,7 @@ void dMeter2Draw_c::drawButtonCross(f32 i_posX, f32 i_posY) {
 #if TARGET_PC
     f32 buttonCrossPosX = i_posX;
     f32 buttonCrossPosY = i_posY;
-    dAnchorHudScale(mpButtonCrossParent, HudCorner::TopLeft, &buttonCrossPosX, &buttonCrossPosY);
+    dAnchorHudScale(mpButtonCrossParent, HudCorner::BottomLeft, &buttonCrossPosX, &buttonCrossPosY);
     mpButtonCrossParent->paneTrans(buttonCrossPosX, buttonCrossPosY);
 #else
     mpButtonCrossParent->paneTrans(i_posX, i_posY);

--- a/src/d/d_meter_map.cpp
+++ b/src/d/d_meter_map.cpp
@@ -24,6 +24,15 @@
 
 #if TARGET_PC
 #include "dusk/action_bindings.h"
+
+namespace {
+
+// Reads the user HUD scale setting, clamped to a safe range.
+f32 dGetUserHudScale() {
+    return std::clamp(dusk::getSettings().game.hudScale.getValue(), 0.5f, 2.0f);
+}
+
+}  // namespace
 #endif
 
 #if (PLATFORM_WII || PLATFORM_SHIELD)
@@ -326,7 +335,7 @@ f32 dMeterMap_c::getMapDispEdgeTop() {
               mMap->getTexelPerCm() * (mMap->getPackZ() + -mMap->getPackPlusZ()) -
               mMap->getTopEdgePlus();
     }
-    f32 rv = getMapDispEdgeBottomY_Layout() - tmp;
+    f32 rv = getMapDispEdgeBottomY_Layout() - tmp IF_DUSK(* dGetUserHudScale());
     return rv;
 }
 
@@ -637,8 +646,7 @@ void dMeterMap_c::draw() {
         #if TARGET_PC
         // Scale the minimap with the user HUD scale and shift down so its bottom-left
         // corner stays anchored to the same screen position as at scale 1.0.
-        const f32 userHudScale =
-            std::clamp(dusk::getSettings().game.hudScale.getValue(), 0.5f, 2.0f);
+        const f32 userHudScale = dGetUserHudScale();
         const f32 scaledSizeX = sizeX * userHudScale;
         const f32 scaledSizeY = sizeY * userHudScale;
         const f32 mapBottomShift = sizeY - scaledSizeY;


### PR DESCRIPTION
Expands on the work initially done by https://github.com/TwilitRealm/dusklight/pull/1387 with the following fixes:

- Immediately applies the new scale to the D-Pad and Rupee UI elements instead of requiring a room change/reload
- Moves the D-Pad element up/down so that it maintains the same distance to the minimap at all scales

Closes https://github.com/TwilitRealm/dusklight/issues/2120

https://github.com/user-attachments/assets/eabd5aee-1559-4999-82e7-6f58eaec9077