### PR TITLE
Fix Overlapping FPS/Pipeline Compilation Overlays

### DIFF
--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -254,6 +254,15 @@ void Overlay::update() {
             mFpsCounter->SetAttribute("open", "");
             mFpsCounter->SetAttribute("corner", kFpsCorners[idx]);
 
+            if(idx == 2 && mPipelineProgress && mPipelineProgress->GetAttribute("open")) {
+                // 12 (height of pipeline box off bottom) + height of pipeline box + 3 (padding space)
+                mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(15 + mPipelineProgress->GetOffsetHeight(), Rml::Unit::PX));
+            }
+            else {
+                // Return fps counter to default height off the bottom
+                mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(12, Rml::Unit::PX));
+            }
+
             const Uint64 perfFreq = SDL_GetPerformanceFrequency();
             float fps = aurora_get_fps();
 


### PR DESCRIPTION
Still overlaps while the pipeline building overlay is fading out, not sure if it's practical to fix unless the opacity can be read from the element during the animation. Could maybe be worked around if the pipeline box moved in from below instead of fading in, so the fps counter could slide up/down with it.

https://github.com/user-attachments/assets/b1b95e24-edee-457c-a3fe-6238ca9c9803

(pipeline cache deleted for the clip so the change is more visible)

