### PR TITLE
FPS Counter Fix

### DIFF
--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -255,14 +255,16 @@ void Overlay::update() {
             mFpsCounter->RemoveProperty(Rml::PropertyId::Bottom);
             mFpsCounter->SetAttribute("corner", kFpsCorners[idx]);
 
-            if(idx == 2) {
-                if(mPipelineProgress && mPipelineProgress->GetAttribute("open")) {
-                    // 12 (height of pipeline box off bottom) + height of pipeline box + 3 (padding space)
-                    mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(15 + mPipelineProgress->GetOffsetHeight(), Rml::Unit::PX));
-                }
-                else {
+            if (idx == 2) {
+                if (mPipelineProgress && mPipelineProgress->GetAttribute("open")) {
+                    // 12 (height of pipeline box off bottom) + height of pipeline box + 3 (padding
+                    // space)
+                    mFpsCounter->SetProperty(Rml::PropertyId::Bottom,
+                        Rml::Property(15 + mPipelineProgress->GetOffsetHeight(), Rml::Unit::PX));
+                } else {
                     // Return fps counter to default height off the bottom
-                    mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(12, Rml::Unit::PX));
+                    mFpsCounter->SetProperty(
+                        Rml::PropertyId::Bottom, Rml::Property(12, Rml::Unit::PX));
                 }
             }
 

--- a/src/dusk/ui/overlay.cpp
+++ b/src/dusk/ui/overlay.cpp
@@ -252,15 +252,18 @@ void Overlay::update() {
         if (getSettings().video.enableFpsOverlay.getValue()) {
             const int idx = getSettings().video.fpsOverlayCorner.getValue();
             mFpsCounter->SetAttribute("open", "");
+            mFpsCounter->RemoveProperty(Rml::PropertyId::Bottom);
             mFpsCounter->SetAttribute("corner", kFpsCorners[idx]);
 
-            if(idx == 2 && mPipelineProgress && mPipelineProgress->GetAttribute("open")) {
-                // 12 (height of pipeline box off bottom) + height of pipeline box + 3 (padding space)
-                mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(15 + mPipelineProgress->GetOffsetHeight(), Rml::Unit::PX));
-            }
-            else {
-                // Return fps counter to default height off the bottom
-                mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(12, Rml::Unit::PX));
+            if(idx == 2) {
+                if(mPipelineProgress && mPipelineProgress->GetAttribute("open")) {
+                    // 12 (height of pipeline box off bottom) + height of pipeline box + 3 (padding space)
+                    mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(15 + mPipelineProgress->GetOffsetHeight(), Rml::Unit::PX));
+                }
+                else {
+                    // Return fps counter to default height off the bottom
+                    mFpsCounter->SetProperty(Rml::PropertyId::Bottom, Rml::Property(12, Rml::Unit::PX));
+                }
             }
 
             const Uint64 perfFreq = SDL_GetPerformanceFrequency();


### PR DESCRIPTION
I broke it in #2198 oops

This removes the `Bottom` property before setting the corner so that any old values set code-side don't persist across location changes. Also ensure we aren't setting a wrong bottom value when the counter is in a top corner.