### PR TITLE
Fixed connection issues, item dupe issues and certain flags not being set

### DIFF
--- a/include/d/d_com_inf_game.h
+++ b/include/d/d_com_inf_game.h
@@ -1187,6 +1187,7 @@ void dComIfGs_setMixItemIndex(int i_no, u8 item_index);
 u8 dComIfGs_getSelectMixItemNoArrowIndex(int i_selmixItemIdx);
 u8 dComIfGs_getMixItemIndex(int i_no);
 u8 dComIfGs_checkGetInsectNum();
+void dComIfGs_syncInsectMiscFlags();
 u8 dComIfGs_checkGetItem(u8 i_itemNo);
 u8 dComIfGs_getBottleMax();
 void dComIfGs_gameStart();

--- a/include/dusk/logging.h
+++ b/include/dusk/logging.h
@@ -19,6 +19,9 @@ namespace dusk {
 extern bool StubLogEnabled;
 
 extern aurora::Module DuskLog;
+// Dedicated module for tracing the AP item-receive -> event-item-queue -> in-game-grant pipeline.
+// Grep the log file for "| ap_items]" to isolate just this flow.
+extern aurora::Module ApItemLog;
 
 #ifndef NDEBUG
 #define STUB_LOG() DuskLog.debug("{} is a stub", __FUNCTION__)

--- a/include/dusk/settings.h
+++ b/include/dusk/settings.h
@@ -187,6 +187,7 @@ struct UserSettings {
         ConfigVar<bool> enableMirrorMode;
         ConfigVar<bool> minimalHUD;
         ConfigVar<float> hudScale;
+        ConfigVar<float> debugUIScale;
         ConfigVar<bool> pauseOnFocusLost;
         ConfigVar<bool> enableLinkDollRotation;
         ConfigVar<bool> enableAchievementToasts;

--- a/src/d/actor/d_a_alink.cpp
+++ b/src/d/actor/d_a_alink.cpp
@@ -13,6 +13,7 @@
 #include "JSystem/JHostIO/JORServer.h"
 #include "JSystem/JKernel/JKRExpHeap.h"
 #include "SSystem/SComponent/c_math.h"
+#include "dusk/logging.h"
 #include "d/d_item.h"
 #include "d/d_meter2_draw.h"
 #include "d/d_pane_class.h"

--- a/src/d/actor/d_a_alink_demo.inc
+++ b/src/d/actor/d_a_alink_demo.inc
@@ -2590,6 +2590,7 @@ int daAlink_c::procCoGetItemInit() {
         }
 #if TARGET_PC
         if (randomizer_IsActive() && g_randomizerState.getGiveItemToPlayerStatus() == RandomizerState::ITEM_IN_QUEUE) {
+            ApItemLog.info("drain: get-item cutscene reached, marking queue slot for clear (item_no={})", item_no);
             g_randomizerState.setGiveItemToPlayerStatus(RandomizerState::CLEAR_QUEUE);
         }
 #endif

--- a/src/d/actor/d_a_e_s1.cpp
+++ b/src/d/actor/d_a_e_s1.cpp
@@ -1693,9 +1693,17 @@ static void demo_camera(e_s1_class* i_this) {
 #if TARGET_PC
                 if (randomizer_IsActive() && daAlink_c::checkStageName("F_SP126")) {
                     // We check to see if the flag being set is for the UZR portal as a safety precaution.
-                    if (i_this->mSwBit == 0x15 && g_dComIfG_gameInfo.info.getSavedata().getPlayer().getPlayerStatusA().getTransformStatus())
+                    // NOTE: this used to also require getTransformStatus() (wolf form) here, despite the
+                    // old comment claiming it was gating on "human" - getTransformStatus() actually
+                    // returns true for WOLF (see d_a_alink_wolf.inc setTransformStatus(1) on wolf
+                    // transform, setTransformStatus(0) on returning to human), so the old check silently
+                    // skipped this whole block whenever the fight was won as human, leaving 0xB02 unset
+                    // even though the switch itself (and thus the portal) had already unlocked. Winning
+                    // the fight in either form should unlock Iza's minigame the same way, so the form
+                    // check has been dropped entirely.
+                    if (i_this->mSwBit == 0x15)
                     {
-                        // Set the flag to make Iza 1 available and set the memory bit for having talked to her after opening the portal as human.
+                        // Set the flag to make Iza 1 available and set the memory bit for having talked to her after opening the portal.
                         dComIfGs_onEventBit(0xB02);
                         dComIfGs_onSwitch(0x37, fopAcM_GetRoomNo(a_this));
                     }

--- a/src/d/actor/d_a_npc_gro.cpp
+++ b/src/d/actor/d_a_npc_gro.cpp
@@ -14,6 +14,8 @@
 #include <cstring>
 
 #if TARGET_PC
+#include "d/d_com_inf_game.h"
+#include "dusk/randomizer/game/flags.h"
 #include "dusk/randomizer/game/verify_item_functions.h"
 #endif
 
@@ -1689,6 +1691,12 @@ int daNpc_grO_c::talk(void* param_1) {
                         if (randomizer_IsActive()) {
                             itemId = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Ebizo Key Shard"));
                             randomizer_setTempFlagForLocation("Goron Mines Gor Ebizo Key Shard");
+                            // Vanilla sets this later in Gor Ebizo's full dialogue tree (see the "late"
+                            // note on this location in locations.yaml), which is also what normally
+                            // lets the player past him up the ladder. The randomizer shortcuts straight
+                            // to spawning the substituted item and skips the rest of that dialogue, so
+                            // without this the flag - and the passage past him - never actually unlocks.
+                            dComIfGs_onEventBit(TALKED_TO_GOR_EBIZO_IN_GORON_MINES);
                         }
 #endif
                         mItemID = fopAcM_createItemForPresentDemo(&current.pos, itemId, 0, -1, -1, NULL, NULL);

--- a/src/d/actor/d_a_npc_gro.cpp
+++ b/src/d/actor/d_a_npc_gro.cpp
@@ -1691,11 +1691,8 @@ int daNpc_grO_c::talk(void* param_1) {
                         if (randomizer_IsActive()) {
                             itemId = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Ebizo Key Shard"));
                             randomizer_setTempFlagForLocation("Goron Mines Gor Ebizo Key Shard");
-                            // Vanilla sets this later in Gor Ebizo's full dialogue tree (see the "late"
-                            // note on this location in locations.yaml), which is also what normally
-                            // lets the player past him up the ladder. The randomizer shortcuts straight
-                            // to spawning the substituted item and skips the rest of that dialogue, so
-                            // without this the flag - and the passage past him - never actually unlocks.
+                            // The randomizer skips the rest of the elder's dialogue; set the
+                            // "talked to" bit here (updateGoalFlags() derives the ladder switches from it).
                             dComIfGs_onEventBit(TALKED_TO_GOR_EBIZO_IN_GORON_MINES);
                         }
 #endif

--- a/src/d/actor/d_a_npc_grr.cpp
+++ b/src/d/actor/d_a_npc_grr.cpp
@@ -1348,11 +1348,8 @@ int daNpc_grR_c::talk(void* param_1) {
                         if (randomizer_IsActive()) {
                             i_itemNo = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Liggs Key Shard"));
                             randomizer_setTempFlagForLocation("Goron Mines Gor Liggs Key Shard");
-                            // Vanilla sets this later in Gor Liggs's full dialogue tree (see the "late"
-                            // note on this location in locations.yaml), which is also what normally
-                            // lets the player past him. The randomizer shortcuts straight to spawning
-                            // the substituted item and skips the rest of that dialogue, so without
-                            // this the flag - and passage past him - never actually unlocks.
+                            // The randomizer skips the rest of the elder's dialogue; set the
+                            // "talked to" bit here (updateGoalFlags() derives the ladder switches from it).
                             dComIfGs_onEventBit(TALKED_TO_GOR_LIGGS_IN_GORON_MINES);
                         }
 #endif

--- a/src/d/actor/d_a_npc_grr.cpp
+++ b/src/d/actor/d_a_npc_grr.cpp
@@ -11,6 +11,8 @@
 #include <cstring>
 
 #if TARGET_PC
+#include "d/d_com_inf_game.h"
+#include "dusk/randomizer/game/flags.h"
 #include "dusk/randomizer/game/verify_item_functions.h"
 #endif
 
@@ -1346,6 +1348,12 @@ int daNpc_grR_c::talk(void* param_1) {
                         if (randomizer_IsActive()) {
                             i_itemNo = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Liggs Key Shard"));
                             randomizer_setTempFlagForLocation("Goron Mines Gor Liggs Key Shard");
+                            // Vanilla sets this later in Gor Liggs's full dialogue tree (see the "late"
+                            // note on this location in locations.yaml), which is also what normally
+                            // lets the player past him. The randomizer shortcuts straight to spawning
+                            // the substituted item and skips the rest of that dialogue, so without
+                            // this the flag - and passage past him - never actually unlocks.
+                            dComIfGs_onEventBit(TALKED_TO_GOR_LIGGS_IN_GORON_MINES);
                         }
 #endif
                         mItemID = fopAcM_createItemForPresentDemo(&current.pos, i_itemNo, 0, -1, -1, NULL, NULL);

--- a/src/d/actor/d_a_npc_grs.cpp
+++ b/src/d/actor/d_a_npc_grs.cpp
@@ -1199,11 +1199,8 @@ int daNpc_grS_c::talk(void* param_0) {
                     if (randomizer_IsActive()) {
                         unkInt2 = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Amato Key Shard"));
                         randomizer_setTempFlagForLocation("Goron Mines Gor Amato Key Shard");
-                        // Vanilla sets this later in Gor Amato's full dialogue tree (see the "late"
-                        // note on this location in locations.yaml), which is also what normally lets
-                        // the player past him. The randomizer shortcuts straight to spawning the
-                        // substituted item and skips the rest of that dialogue, so without this the
-                        // flag - and passage past him - never actually unlocks.
+                        // The randomizer skips the rest of the elder's dialogue; set the
+                        // "talked to" bit here (updateGoalFlags() derives the ladder switches from it).
                         dComIfGs_onEventBit(TALKED_TO_GOR_AMATO_IN_GORON_MINES);
                     }
 #endif

--- a/src/d/actor/d_a_npc_grs.cpp
+++ b/src/d/actor/d_a_npc_grs.cpp
@@ -12,6 +12,8 @@
 #include <cstring>
 
 #if TARGET_PC
+#include "d/d_com_inf_game.h"
+#include "dusk/randomizer/game/flags.h"
 #include "dusk/randomizer/game/verify_item_functions.h"
 #endif
 enum Event_Cut_Nums {
@@ -1197,6 +1199,12 @@ int daNpc_grS_c::talk(void* param_0) {
                     if (randomizer_IsActive()) {
                         unkInt2 = verifyProgressiveItem(randomizer_getItemAtLocation("Goron Mines Gor Amato Key Shard"));
                         randomizer_setTempFlagForLocation("Goron Mines Gor Amato Key Shard");
+                        // Vanilla sets this later in Gor Amato's full dialogue tree (see the "late"
+                        // note on this location in locations.yaml), which is also what normally lets
+                        // the player past him. The randomizer shortcuts straight to spawning the
+                        // substituted item and skips the rest of that dialogue, so without this the
+                        // flag - and passage past him - never actually unlocks.
+                        dComIfGs_onEventBit(TALKED_TO_GOR_AMATO_IN_GORON_MINES);
                     }
 #endif
                     mPresentItemId =

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -2817,18 +2817,18 @@ JKRExpHeap* dComIfGp_getSubHeap2D(int flag) {
     return NULL;
 }
 
+static u8 l_insect_itemno[24] = {
+    dItemNo_M_BEETLE_e,      dItemNo_F_BEETLE_e,      dItemNo_M_BUTTERFLY_e, dItemNo_F_BUTTERFLY_e, dItemNo_M_STAG_BEETLE_e, dItemNo_F_STAG_BEETLE_e,
+    dItemNo_M_GRASSHOPPER_e, dItemNo_F_GRASSHOPPER_e, dItemNo_M_NANAFUSHI_e, dItemNo_F_NANAFUSHI_e, dItemNo_M_DANGOMUSHI_e,  dItemNo_F_DANGOMUSHI_e,
+    dItemNo_M_MANTIS_e,      dItemNo_F_MANTIS_e,      dItemNo_M_LADYBUG_e,   dItemNo_F_LADYBUG_e,   dItemNo_M_SNAIL_e,       dItemNo_F_SNAIL_e,
+    dItemNo_M_DRAGONFLY_e,   dItemNo_F_DRAGONFLY_e,   dItemNo_M_ANT_e,       dItemNo_F_ANT_e,       dItemNo_M_MAYFLY_e,      dItemNo_F_MAYFLY_e,
+};
+
 u8 dComIfGs_checkGetInsectNum() {
-    static u8 l_itemno[24] = {
-        dItemNo_M_BEETLE_e,      dItemNo_F_BEETLE_e,      dItemNo_M_BUTTERFLY_e, dItemNo_F_BUTTERFLY_e, dItemNo_M_STAG_BEETLE_e, dItemNo_F_STAG_BEETLE_e,
-        dItemNo_M_GRASSHOPPER_e, dItemNo_F_GRASSHOPPER_e, dItemNo_M_NANAFUSHI_e, dItemNo_F_NANAFUSHI_e, dItemNo_M_DANGOMUSHI_e,  dItemNo_F_DANGOMUSHI_e,
-        dItemNo_M_MANTIS_e,      dItemNo_F_MANTIS_e,      dItemNo_M_LADYBUG_e,   dItemNo_F_LADYBUG_e,   dItemNo_M_SNAIL_e,       dItemNo_F_SNAIL_e,
-        dItemNo_M_DRAGONFLY_e,   dItemNo_F_DRAGONFLY_e,   dItemNo_M_ANT_e,       dItemNo_F_ANT_e,       dItemNo_M_MAYFLY_e,      dItemNo_F_MAYFLY_e,
-    };
-
     u8 insectCount = 0;
-    u8* insectList = l_itemno;
+    u8* insectList = l_insect_itemno;
 
-    for (int i = 0; i < ARRAY_SIZEU(l_itemno); i++) {
+    for (int i = 0; i < ARRAY_SIZEU(l_insect_itemno); i++) {
         if (dComIfGs_isItemFirstBit(*insectList++) &&
             dComIfGs_isEventBit(dSv_event_flag_c::saveBitLabels[0x191 + i]))
         {
@@ -2836,6 +2836,22 @@ u8 dComIfGs_checkGetInsectNum() {
         }
     }
     return insectCount;
+}
+
+// Golden bugs granted outside of their overworld pickup actor (i.e. from the randomizer/Archipelago
+// item-get path) only ever set the item's "first obtained" bit - item_func_M_BEETLE and friends are
+// empty, since normally the overworld actor itself sets its species' saveBitLabels[0x191 + i] "Misc."
+// flag via setSaveBitNo(). Without that second flag, dComIfGs_checkGetInsectNum() undercounts, so
+// Agitha (and the bug menu) treat shuffled bugs as never collected. Call this after any item get to
+// backfill the missing flag for every species already marked as obtained.
+void dComIfGs_syncInsectMiscFlags() {
+    for (int i = 0; i < ARRAY_SIZEU(l_insect_itemno); i++) {
+        if (dComIfGs_isItemFirstBit(l_insect_itemno[i]) &&
+            !dComIfGs_isEventBit(dSv_event_flag_c::saveBitLabels[0x191 + i]))
+        {
+            dComIfGs_onEventBit(dSv_event_flag_c::saveBitLabels[0x191 + i]);
+        }
+    }
 }
 
 u8 dComIfGs_checkGetItem(u8 i_itemNo) {

--- a/src/d/d_com_inf_game.cpp
+++ b/src/d/d_com_inf_game.cpp
@@ -15,6 +15,7 @@
 #include "d/d_menu_window_HIO.h"
 #include "d/d_meter2_info.h"
 #include "d/d_meter_HIO.h"
+#include "d/d_msg_object.h"
 #include "d/d_simple_model.h"
 #include "d/d_timer.h"
 #include "f_op/f_op_msg_mng.h"
@@ -2985,6 +2986,13 @@ void dComIfGs_setupRandomizerSave() {
     for (const auto& flag : randoData.mStartEventFlags) {
         dComIfGs_onEventBit(flag);
     }
+
+    // Head-start both donation counters to 950 (goal is 1000) so only a small final donation finishes them.
+    dMsgObject_setOffering(950); // Charlo
+    if (randoData.mSettings[RandomizerContext::SKIP_BRIDGE_DONATION] == RandomizerContext::OFF) {
+        dMsgObject_setFundRaising(950); // Malo Mart bridge
+    }
+
     // Region Flags
     for (const auto& [region, flags] : randoData.mStartRegionFlags) {
         for (const auto& flag : flags) {

--- a/src/d/d_item.cpp
+++ b/src/d/d_item.cpp
@@ -8,6 +8,7 @@
 #include "d/d_item.h"
 #include "d/d_com_inf_game.h"
 #include "d/d_meter2_info.h"
+#include "dusk/logging.h"
 #if TARGET_PC
 #include "dusk/randomizer/game/flags.h"
 #include "dusk/randomizer/game/tools.h"
@@ -541,6 +542,7 @@ static void (*item_func_ptr_randomizer[256])() = {
 
 inline void getItemFunc(u8 i_itemNo) {
     dComIfGs_onItemFirstBit(i_itemNo);
+    dComIfGs_syncInsectMiscFlags();
 #if TARGET_PC
     (randomizer_IsActive() ? item_func_ptr_randomizer : item_func_ptr)[i_itemNo]();
 #else
@@ -1814,54 +1816,53 @@ void item_func_HORSE_FLUTE() {
 }
 
 #if TARGET_PC
+// Logged so a double-increment (two calls for what should be one server-sent key) is directly
+// visible in the log, rather than only showing up as an unexplained gap between the server's
+// authoritative send count and the in-game held count.
+static void logged_incrementKeyNum(const char* dungeonName, u8 keyType) {
+    u8 currentKeys = dComIfGs_getKeyNum(keyType);
+    DuskLog.info("item_func: incrementing {} small key count {} -> {}", dungeonName, currentKeys, currentKeys + 1);
+    dComIfGs_setKeyNum(keyType, currentKeys + 1);
+}
+
 void item_func_FOREST_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x10);
-    dComIfGs_setKeyNum(0x10, currentKeys + 1);
+    logged_incrementKeyNum("Forest Temple", 0x10);
 }
 
 void item_func_MINES_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x11);
-    dComIfGs_setKeyNum(0x11, currentKeys + 1);
+    logged_incrementKeyNum("Goron Mines", 0x11);
 }
 
 void item_func_LAKEBED_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x12);
-    dComIfGs_setKeyNum(0x12, currentKeys + 1);
+    logged_incrementKeyNum("Lakebed Temple", 0x12);
 }
 
 void item_func_ARBITERS_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x13);
-    dComIfGs_setKeyNum(0x13, currentKeys + 1);
+    logged_incrementKeyNum("Arbiters Grounds", 0x13);
 }
 
 void item_func_SNOWPEAK_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x14);
-    dComIfGs_setKeyNum(0x14, currentKeys + 1);
+    logged_incrementKeyNum("Snowpeak Ruins", 0x14);
 }
 
 void item_func_TEMPLE_OF_TIME_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x15);
-    dComIfGs_setKeyNum(0x15, currentKeys + 1);
+    logged_incrementKeyNum("Temple of Time", 0x15);
 }
 
 void item_func_CITY_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x16);
-    dComIfGs_setKeyNum(0x16, currentKeys + 1);
+    logged_incrementKeyNum("City in the Sky", 0x16);
 }
 
 void item_func_PALACE_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x17);
-    dComIfGs_setKeyNum(0x17, currentKeys + 1);
+    logged_incrementKeyNum("Palace of Twilight", 0x17);
 }
 
 void item_func_HYRULE_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0x18);
-    dComIfGs_setKeyNum(0x18, currentKeys + 1);
+    logged_incrementKeyNum("Hyrule Castle", 0x18);
 }
 
 void item_func_CAMP_SMALL_KEY() {
-    u8 currentKeys = dComIfGs_getKeyNum(0xA);
-    dComIfGs_setKeyNum(0xA, currentKeys + 1);
+    logged_incrementKeyNum("Bulblin Camp", 0xA);
 }
 
 void item_func_LAKE_HYLIA_PORTAL() {

--- a/src/dusk/archipelago/archipelago_context.cpp
+++ b/src/dusk/archipelago/archipelago_context.cpp
@@ -1,6 +1,7 @@
 #include <dusk/archipelago/archipelago_context.hpp>
 
 #include <array>
+#include <deque>
 #include <thread>
 #include <unordered_map>
 
@@ -180,6 +181,10 @@ static const std::unordered_map<std::string, std::string> sStageCodeToName = {
 // Reads the null-or-length-terminated 8 byte stage code out of the live game state.
 static std::string ReadCurrentStageCode() {
     const char* raw = dComIfGp_getStartStageName();
+    if (raw == nullptr) {
+        // null between stages / during load
+        return {};
+    }
     std::string code;
     for (int i = 0; i < 8 && raw[i] != '\0'; ++i) {
         code.push_back(raw[i]);
@@ -211,49 +216,65 @@ static std::string ToJsonStringLiteral(const std::string& value) {
     return out;
 }
 
-static void SetTrackedIntDataStorage(const std::string& key, int value, int defaultValue) {
+// AP_BulkSetServerData() stashes &request->status and AP_CommitServerData() writes back through it
+// later, so the request must outlive the commit. The caller keeps these in a std::deque (stable
+// element addresses) rather than a local that dies on helper return.
+struct PendingServerData {
     AP_SetServerDataRequest request;
-    request.key = key;
-    request.type = AP_DataType::Int;
-    request.want_reply = false;
-    request.default_value = &defaultValue;
+    std::string jsonDefault;
+    std::string jsonValue;
+    int intDefault = 0;
+    int intValue = 0;
+};
+
+static void SetTrackedIntDataStorage(std::deque<PendingServerData>& pending,
+    const std::string& key, int value, int defaultValue) {
+    auto& p = pending.emplace_back();
+    p.intValue = value;
+    p.intDefault = defaultValue;
+    p.request.key = key;
+    p.request.type = AP_DataType::Int;
+    p.request.want_reply = false;
+    p.request.default_value = &p.intDefault;
     AP_DataStorageOperation replaceOp;
     replaceOp.operation = "replace";
-    replaceOp.value = &value;
-    request.operations = {replaceOp};
-    AP_BulkSetServerData(&request);
+    replaceOp.value = &p.intValue;
+    p.request.operations = {replaceOp};
+    AP_BulkSetServerData(&p.request);
 }
 
-static void SetTrackedStringDataStorage(const std::string& key, const std::string& value, const std::string& defaultValue) {
-    AP_SetServerDataRequest request;
-    request.key = key;
-    request.type = AP_DataType::Raw;
-    request.want_reply = false;
-    std::string jsonDefault = ToJsonStringLiteral(defaultValue);
-    request.default_value = &jsonDefault;
-    std::string jsonValue = ToJsonStringLiteral(value);
+static void SetTrackedStringDataStorage(std::deque<PendingServerData>& pending,
+    const std::string& key, const std::string& value, const std::string& defaultValue) {
+    auto& p = pending.emplace_back();
+    p.jsonDefault = ToJsonStringLiteral(defaultValue);
+    p.jsonValue = ToJsonStringLiteral(value);
+    p.request.key = key;
+    p.request.type = AP_DataType::Raw;
+    p.request.want_reply = false;
+    p.request.default_value = &p.jsonDefault;
     AP_DataStorageOperation replaceOp;
     replaceOp.operation = "replace";
-    replaceOp.value = &jsonValue;
-    request.operations = {replaceOp};
-    AP_BulkSetServerData(&request);
+    replaceOp.value = &p.jsonValue;
+    p.request.operations = {replaceOp};
+    AP_BulkSetServerData(&p.request);
 }
 
 // Sent as bare JSON literals (true/false), not JSON strings, matching the apworld client and what
 // poptracker's autotracking expects.
-static void SetTrackedBoolDataStorage(const std::string& key, bool value, bool defaultValue) {
-    AP_SetServerDataRequest request;
-    request.key = key;
-    request.type = AP_DataType::Raw;
-    request.want_reply = false;
-    std::string jsonDefault = defaultValue ? "true" : "false";
-    request.default_value = &jsonDefault;
-    std::string jsonValue = value ? "true" : "false";
+static void SetTrackedBoolDataStorage(std::deque<PendingServerData>& pending,
+    const std::string& key, bool value, bool defaultValue) {
+    auto& p = pending.emplace_back();
+    p.jsonDefault = defaultValue ? "true" : "false";
+    p.jsonValue = value ? "true" : "false";
+    p.request.key = key;
+    p.request.type = AP_DataType::Raw;
+    p.request.want_reply = false;
+    p.request.default_value = &p.jsonDefault;
     AP_DataStorageOperation replaceOp;
     replaceOp.operation = "replace";
-    replaceOp.value = &jsonValue;
-    request.operations = {replaceOp};
-    AP_BulkSetServerData(&request);
+    replaceOp.value = &p.jsonValue;
+    p.request.operations = {replaceOp};
+    AP_BulkSetServerData(&p.request);
 }
 
 // Howling Stones: byte+bitmask offsets into dComIfGs_getSaveInfo(), from the apworld's
@@ -349,6 +370,10 @@ const char* getMessageTypeName(AP_MessageType type) {
 
 void ParseMessageData() {
     auto msg = AP_GetLatestMessage();
+    if (msg == nullptr) {
+        // race with the pending-message poll
+        return;
+    }
 
     switch (msg->type) {
     case AP_MessageType::ItemSend: {
@@ -726,31 +751,34 @@ void ArchipelagoContext::UpdateMapTrackingData() {
     const int slot = AP_GetPlayerID();
     const std::string keyPrefix = "TP_" + std::to_string(team) + "_" + std::to_string(slot) + "_";
 
+    // requests must outlive the AP_CommitServerData() below
+    std::deque<PendingServerData> pending;
+
     std::string stageCode = ReadCurrentStageCode();
     const std::string* stageName = ResolveStageName(stageCode);
     if (!stageName) {
         DuskLog.warn("UpdateMapTrackingData: unrecognized stage code '{}', not sending Current Stage update", stageCode);
     } else if (*stageName != instance().m_lastSentStageName) {
-        SetTrackedStringDataStorage(keyPrefix + "Current Stage", *stageName, "Menu");
+        SetTrackedStringDataStorage(pending, keyPrefix + "Current Stage", *stageName, "Menu");
         instance().m_lastSentStageName = *stageName;
     }
 
     int room = dStage_roomControl_c::getStayNo();
     if (room != instance().m_lastSentRoom) {
-        SetTrackedIntDataStorage(keyPrefix + "Current Room", room, -1);
+        SetTrackedIntDataStorage(pending, keyPrefix + "Current Room", room, -1);
         instance().m_lastSentRoom = room;
     }
 
     // Send the raw unsigned byte (basements wrap to 255/254/253), matching the apworld's client.
     int floor = static_cast<u8>(dMapInfo_c::mNowStayFloorNo);
     if (floor != instance().m_lastSentFloor) {
-        SetTrackedIntDataStorage(keyPrefix + "Current Floor", floor, -1);
+        SetTrackedIntDataStorage(pending, keyPrefix + "Current Floor", floor, -1);
         instance().m_lastSentFloor = floor;
     }
 
     int layer = dComIfGp_getStartStageLayer();
     if (layer != instance().m_lastSentLayer) {
-        SetTrackedIntDataStorage(keyPrefix + "Current Layer", layer, -1);
+        SetTrackedIntDataStorage(pending, keyPrefix + "Current Layer", layer, -1);
         instance().m_lastSentLayer = layer;
     }
 
@@ -763,12 +791,15 @@ void ArchipelagoContext::UpdateFlagTrackingData() {
     const int slot = AP_GetPlayerID();
     const std::string keyPrefix = "TP_" + std::to_string(team) + "_" + std::to_string(slot) + "_";
 
+    // requests must outlive the AP_CommitServerData() below
+    std::deque<PendingServerData> pending;
+
     for (const auto& entry : sFlagTrackingEntries) {
         bool value = ReadSaveInfoFlag(entry.offset, entry.mask);
         auto it = instance().m_lastSentFlags.find(entry.key);
         if (it != instance().m_lastSentFlags.end() && it->second == value)
             continue;
-        SetTrackedBoolDataStorage(keyPrefix + entry.key, value, false);
+        SetTrackedBoolDataStorage(pending, keyPrefix + entry.key, value, false);
         instance().m_lastSentFlags[entry.key] = value;
     }
 
@@ -777,7 +808,7 @@ void ArchipelagoContext::UpdateFlagTrackingData() {
         auto it = instance().m_lastSentFlags.find(entry.key);
         if (it != instance().m_lastSentFlags.end() && it->second == value)
             continue;
-        SetTrackedBoolDataStorage(keyPrefix + entry.key, value, false);
+        SetTrackedBoolDataStorage(pending, keyPrefix + entry.key, value, false);
         instance().m_lastSentFlags[entry.key] = value;
     }
 
@@ -788,7 +819,7 @@ void ArchipelagoContext::UpdateFlagTrackingData() {
         auto it = instance().m_lastSentFlags.find(entry.key);
         if (it != instance().m_lastSentFlags.end() && it->second == defeated)
             continue;
-        SetTrackedBoolDataStorage(keyPrefix + entry.key, defeated, false);
+        SetTrackedBoolDataStorage(pending, keyPrefix + entry.key, defeated, false);
         instance().m_lastSentFlags[entry.key] = defeated;
     }
 
@@ -1139,6 +1170,11 @@ void ArchipelagoContext::HandleReceiveLocationScout(const std::vector<AP_Network
 // so eventually finding a way to properly associate locations with their respective item get funcs would benefit this system
 void ArchipelagoContext::UpdateCheckedLocations(bool warnIfNoChange) {
     auto& world = instance().m_archiWorld;
+    if (world == nullptr) {
+        // Execute() calls this every frame once scouts arrive; world data may not be ready yet
+        DuskLog.warn("UpdateCheckedLocations: archipelago world not generated yet - skipping");
+        return;
+    }
     std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     bool changed = false;
@@ -1179,6 +1215,8 @@ void ArchipelagoContext::SetNeedUpdateLocations(bool update) {
 
 bool ArchipelagoContext::IsLocationChecked(int locId) {
     auto& world = instance().m_archiWorld;
+    if (world == nullptr)
+        return false;
     std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
@@ -1201,6 +1239,8 @@ bool ArchipelagoContext::hasAtomicLocalGrant(int64_t apLocationId) {
     // The category list this checks against (RandomizerContext::kAtomicallyGrantedLocationCategories)
     // is shared with randomizer_context.cpp's world-gen override-table population, so the two sides
     // can't drift independently - see that constant's declaration for the full reasoning.
+    if (m_archiWorld == nullptr)
+        return false;
     std::lock_guard<std::mutex> lock(m_locationInfoMutex);
     for (const auto& [locName, locInfo] : m_locationItemInfo) {
         if (locInfo.apLocationId == apLocationId) {
@@ -1244,7 +1284,7 @@ void ArchipelagoContext::SetLocationChecked(int locId, bool collected) {
             locInfo.collected = collected;
 
             // update location flags if possible
-            auto location = world->GetLocation(locInfo.locationName, true);
+            auto location = world ? world->GetLocation(locInfo.locationName, true) : nullptr;
             if (!location || !location->IsProgression())
                 return;
 
@@ -1258,6 +1298,8 @@ void ArchipelagoContext::SetLocationChecked(int locId, bool collected) {
 
 void ArchipelagoContext::UpdateLocationState(int locId, bool collected) {
     auto& world = instance().m_archiWorld;
+    if (world == nullptr)
+        return;
     std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
@@ -1276,6 +1318,8 @@ void ArchipelagoContext::UpdateLocationState(int locId, bool collected) {
 
 void ArchipelagoContext::UpdateAllLocationState() {
     auto& world = instance().m_archiWorld;
+    if (world == nullptr)
+        return;
     std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     // TODO: find out why some locations seem to keep their collection state upon reset (bugs)
 
@@ -1418,7 +1462,12 @@ void ArchipelagoContext::CreateArchipelagoWorld() {
     auto trackerRando = randomizer::Randomizer(workingDir);
     trackerRando.GenerateTrackerWorld(false);
 
-    instance().m_archiWorld = std::move(trackerRando.GetWorlds().front());
+    auto& worlds = trackerRando.GetWorlds();
+    if (worlds.empty()) {
+        DuskLog.error("CreateArchipelagoWorld: GenerateTrackerWorld produced no worlds - archipelago world stays null");
+        return;
+    }
+    instance().m_archiWorld = std::move(worlds.front());
 }
 
 void ArchipelagoContext::FillArchipelagoWorld() {
@@ -1469,6 +1518,10 @@ void ArchipelagoContext::FillArchipelagoWorld() {
 
 void ArchipelagoContext::CreateRandomizerContext() {
     auto& world = instance().m_archiWorld;
+    if (world == nullptr) {
+        DuskLog.error("CreateRandomizerContext: archipelago world was not created - aborting");
+        return;
+    }
 
     // Set hint texts before writing context
     randomizer::logic::hints::GenerateAllHints(world);

--- a/src/dusk/archipelago/archipelago_context.cpp
+++ b/src/dusk/archipelago/archipelago_context.cpp
@@ -1,8 +1,10 @@
 #include <dusk/archipelago/archipelago_context.hpp>
 
+#include <array>
 #include <thread>
 
 #include "Archipelago.h"
+#include "d/d_com_inf_game.h"
 #include "d/d_item.h"
 #include "d/actor/d_a_alink.h"
 #include "dusk/config.hpp"
@@ -28,9 +30,9 @@ struct SettingsNameConvert {
 
     const std::string& tryGetOptionConvert(const std::string& option) const {
         if (optionsConvert.empty()) {
-            if (option == "Yes")
+            if (option == "Yes" || option == "True" || option == "true")
                 return kDefaultYes;
-            if (option == "No")
+            if (option == "No" || option == "False" || option == "false")
                 return kDefaultNo;
             return option;
         }
@@ -99,7 +101,9 @@ static auto sArchiSettingToDusklight = std::to_array<SettingsNameConvert>({
     }},
     {"Poes Shuffled", "Poe Souls", {
         {"Yes", "All"},
-        {"No", "Vanilla"}
+        {"No", "Vanilla"},
+        {"True", "All"},
+        {"False", "Vanilla"}
     }}
 });
 
@@ -249,9 +253,14 @@ void ArchipelagoContext::itemRecvImpl(int id, bool notify) {
 
     if (notify && item.importance == randomizer::logic::item::Importance::MAJOR) {
         DuskLog.info("[AP] Adding Item: {}", item.itemName);
-        g_randomizerState.addItemToEventQueue(verifyProgressiveItem(item.itemId));
+        auto verifiedId = verifyProgressiveItem(item.itemId);
+        ApItemLog.info("recv: '{}' (apId {} -> gameItemId {} -> verified {}), routing to event queue",
+            item.itemName, id, item.itemId, verifiedId);
+        g_randomizerState.addItemToEventQueue(verifiedId);
     }else {
         DuskLog.info("[AP] Silently Adding Item: {}", item.itemName);
+        ApItemLog.info("recv: '{}' (apId {} -> gameItemId {}), granting directly via execItemGet",
+            item.itemName, id, item.itemId);
         execItemGet(item.itemId);
     }
 
@@ -372,6 +381,24 @@ bool ArchipelagoContext::IsCurrentSeedHash(const std::string& seedStr) {
 bool ArchipelagoContext::ConnectToServer(int file, bool isBlocking) {
     config::Save();
 
+    // m_locationItemInfo (and the collect-state snapshot it seeds from) is never otherwise cleared,
+    // so a reconnect within the same process run would see the prior session's stale location data.
+    // IsReceivedLocationScouts() (`!m_locationItemInfo.empty()`) would then report true immediately,
+    // skipping the wait for the new session's real scout response and letting GenerateLocalWorldData()
+    // proceed against last session's location/item info. m_receivedItemsQueue has the same problem -
+    // items queued via HandleItemReceived() before a disconnect (e.g. the scout-retry loop's
+    // Disconnect/reconnect cycle) would otherwise survive into the new session and get drained
+    // against data from a different connection attempt.
+    {
+        std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
+        instance().m_locationItemInfo.clear();
+        instance().m_initLocationCollectState.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock(instance().m_queueMutex);
+        instance().m_receivedItemsQueue.clear();
+    }
+
     instance().LoadTempItemInfo();
 
     instance().LoadTempLocationInfo();
@@ -475,6 +502,11 @@ void ArchipelagoContext::Execute() {
     if (!IsConnected())
         return;
 
+    // backfill the per-species "Misc." flag for any golden bugs already obtained before this fix
+    // existed, so previously-received bugs are picked up by Agitha/the bug menu without needing to
+    // receive a new item first
+    dComIfGs_syncInsectMiscFlags();
+
     // reset player inventory if server requested it
     if (instance().m_isNeedResetInv) {
         HandleResetInventory();
@@ -488,16 +520,41 @@ void ArchipelagoContext::Execute() {
         return;
     }
 
-    // drain pending item queue here
-    instance().m_queueMutex.lock();
-    if (!instance().m_receivedItemsQueue.empty()) {
-        for (auto item : instance().m_receivedItemsQueue) {
-            instance().itemRecvImpl(item.first, item.second);
+    // Drain pending item queue here. HandleItemReceived() on the AP network thread needs
+    // m_queueMutex just to enqueue, so the lock is only held long enough to swap the queue out into
+    // a local vector, and all the actual (possibly slow) processing happens after unlocking, so a
+    // burst of items doesn't block the network thread's ability to enqueue more.
+    //
+    // Hold the whole queue until location scouts are back - shouldSkipDuplicateItem() needs
+    // m_locationItemInfo fully populated to correctly dedup (self or foreign) items tied to a
+    // location, and this runs every frame, so this is a short deferral on first connect, not a
+    // hang. Processing the batch in order (rather than skipping just the unready entries) keeps
+    // items applied in the order they were received.
+    std::vector<ReceivedItemEntry> itemsToProcess;
+    {
+        std::lock_guard<std::mutex> lock(instance().m_queueMutex);
+        if (!instance().m_receivedItemsQueue.empty() && IsReceivedLocationScouts()) {
+            // std::vector move-assignment already leaves the source empty - no need to also clear() it.
+            itemsToProcess = std::move(instance().m_receivedItemsQueue);
         }
-
-        instance().m_receivedItemsQueue.clear();
     }
-    instance().m_queueMutex.unlock();
+
+    // shouldSkipDuplicateItem() only records new dedup entries in-memory (mProcessedNetworkItems);
+    // persist once here, after the whole batch, instead of once per newly-processed item - a
+    // multi-item resync burst would otherwise do N synchronous full-context seed.dat writes on the
+    // main thread in a single frame.
+    size_t processedCountBefore = randomizer_GetContext().mProcessedNetworkItems.size();
+
+    for (auto& item : itemsToProcess) {
+        if (instance().shouldSkipDuplicateItem(item))
+            continue;
+
+        instance().itemRecvImpl(item.relativeId, item.notify);
+    }
+
+    if (randomizer_GetContext().mProcessedNetworkItems.size() != processedCountBefore) {
+        instance().persistProcessedItems();
+    }
 
     // update location checks here if we need to
     if (instance().m_isUpdateLocations) {
@@ -509,20 +566,165 @@ void ArchipelagoContext::Execute() {
 void ArchipelagoContext::HandleItemReceived(AP_NetworkItem& netItem, bool notify) {
     int relativeId = netItem.item - ARCHI_ITEM_OFFSET;
 
+    ApItemLog.info("HandleItemReceived: raw item={} location={} player={} notify={} relativeId={}",
+        netItem.item, netItem.location, netItem.player, notify, relativeId);
+
     // TODO: modify this to also include junk items like ammo
     if (!notify && ((relativeId >= 0 && relativeId <= 6) || relativeId == 7)) {
         // skip rupee refills so players cant abuse disconnect/reconnect
+        ApItemLog.info("HandleItemReceived: skipped (rupee refill dedup)");
         return;
     }
 
-    if (!instance().m_isNeedResetInv && netItem.location != -1 && IsLocationChecked(netItem.location)) {
-        // no need to handle item if its location has already been checked
-        return;
-    }
+    // The location-based dedup check (see shouldSkipDuplicateItem()) depends on m_locationItemInfo,
+    // which is populated asynchronously by location scouts (AP_SetLocationInfoCallback), and on
+    // GetSeedDirectoryPath(), which depends on IsConnected(). Neither is guaranteed ready yet when
+    // this callback fires - it runs on the AP network thread as soon as a message arrives, which can
+    // be before scouts return or before the client-side connection state has settled, especially
+    // during the very first resync burst right after a reconnect. Running the dedup check here would
+    // race against that state and silently under-dedup. So we capture everything the dedup check
+    // will need and defer the actual check to the main thread's queue drain in Execute(), which only
+    // runs once IsConnected() is true and (per the drain loop) only processes the queue once location
+    // scouts have actually come back.
+    ApItemLog.info("HandleItemReceived: pushed to receive queue (relativeId={}, notify={})", relativeId, notify);
 
     instance().m_queueMutex.lock();
-    instance().m_receivedItemsQueue.push_back({relativeId, notify});
+    instance().m_receivedItemsQueue.push_back({relativeId, notify, netItem.player, netItem.location, instance().m_isNeedResetInv});
     instance().m_queueMutex.unlock();
+}
+
+void ArchipelagoContext::persistProcessedItems() {
+    std::filesystem::path workingDir;
+    GetSeedDirectoryPath(workingDir);
+    // GetSeedDirectoryPath() silently leaves workingDir untouched (empty) if IsConnected() is
+    // false at the exact moment this runs - which would make the write below silently target
+    // a bogus relative "seed.dat" instead of the real seed folder, never actually persisting
+    // this dedup entry. This is now called from Execute(), which only runs while IsConnected()
+    // is true, so this should be rare in practice, but IsConnected() isn't re-checked between
+    // Execute()'s top-of-function guard and this call, so a disconnect racing in between is a
+    // real (if narrow) window - log loudly instead of failing silently.
+    if (workingDir.empty()) {
+        ApItemLog.error("persistProcessedItems: GetSeedDirectoryPath() returned empty - "
+            "IsConnected()={}, cannot persist new dedup entries!", IsConnected());
+        return;
+    }
+    auto writeResult = randomizer_GetContext().WriteToFile(workingDir / "seed.dat");
+    if (writeResult.has_value()) {
+        ApItemLog.error("persistProcessedItems: failed to persist dedup entries to {}: {}",
+            (workingDir / "seed.dat").string(), writeResult.value());
+    } else {
+        ApItemLog.info("persistProcessedItems: persisted dedup entries to {}", (workingDir / "seed.dat").string());
+    }
+}
+
+bool ArchipelagoContext::shouldSkipDuplicateItem(const ReceivedItemEntry& entry) {
+    // Small Key items (AP ids 54-62 for the 9 dungeons, 66 for the Bulblin Camp key) are pure
+    // interchangeable counters with no "already have this one" gating in their item_func - unlike
+    // most items, re-processing an already-received key is NOT idempotent, it just adds another.
+    // The reset-inventory wipe never touches key counts at all (they live in separate per-stage save
+    // data, not the general inventory getItem() wipes), so on every single reconnect (which triggers
+    // this reset unconditionally, per AP protocol) skipping the dedup below would let the entire
+    // key-receive history replay and re-increment on top of whatever was already there - including
+    // keys already spent opening doors, since consumption isn't tracked here at all. So keys must
+    // always be deduped, reset or not; everything else keeps the original reset-bypass behavior,
+    // since re-granting equipment/one-off items after the wipe is harmless.
+    //
+    // Progressive Sky Book (AP id 123) has the exact same problem despite looking flag-gated at the
+    // top level: getProgressiveSkybook() resolves every receive after the first two into "Air Letter",
+    // which does the same unconditional dComIfGs_setAncientDocumentNum(letterCount + 1) with no
+    // "already counted" check - so it's just as vulnerable to replay-induced over-counting as keys.
+    //
+    // Piece of Heart / Heart Container (AP ids 23/24) are the same shape of bug: item_func_KAKERA_HEART/
+    // UTUWA_HEART call dComIfGp_setItemMaxLifeCount(), which does an unconditional mItemMaxLifeCount +=
+    // max - re-processing one of these on replay permanently inflates max health.
+    const bool isSmallKeyItem = (entry.relativeId >= 54 && entry.relativeId <= 62) || entry.relativeId == 66;
+    const bool isSkyBookItem = entry.relativeId == 123;
+    const bool isHeartItem = entry.relativeId == 23 || entry.relativeId == 24;
+    const bool isNonIdempotentCounter = isSmallKeyItem || isSkyBookItem || isHeartItem;
+
+    // Items delivered with no location (AP's "precollected"/start-inventory items, which the
+    // pre-existing `netItem.location != -1` check this replaced already anticipated as a real,
+    // expected value) can't use any location-based dedup at all. For ordinary items that's fine -
+    // re-granting an idempotent item is harmless - but the non-idempotent counters above still need
+    // *some* persistent dedup, or a location-less key/skybook/heart delivery would replay and
+    // over-count on every single reconnect with zero protection. Dedup those via (player,
+    // relativeId) instead, in a key range (bit 47 set) that can never collide with a real
+    // apLocationId, which this codebase's location ids never approach.
+    if (entry.location == -1) {
+        if (!isNonIdempotentCounter)
+            return false;
+
+        auto& processedItems = randomizer_GetContext().mProcessedNetworkItems;
+        constexpr int64_t kLocationlessDedupBase = 0x800000000000LL;
+        u64 key = RandomizerContext::EncodeNetworkItemKey(entry.player, kLocationlessDedupBase | entry.relativeId);
+        if (processedItems.contains(key)) {
+            ApItemLog.info("shouldSkipDuplicateItem: skipped, already processed location-less item relativeId={} for player {}",
+                entry.relativeId, entry.player);
+            return true;
+        }
+        // Persistence is batched by the caller (Execute()) after the whole drain loop, not per-item.
+        processedItems.insert(key);
+        return false;
+    }
+
+    // entry.wasResetPending captures m_isNeedResetInv as it was at the moment the item was actually
+    // received (in HandleItemReceived, on the network thread) - by the time this runs, on a later
+    // Execute() call, m_isNeedResetInv has always already been cleared, so re-reading it live here
+    // would make this condition always true and change behavior for non-counter items.
+    const bool shouldDedup = isNonIdempotentCounter || !entry.wasResetPending;
+
+    // Chests and the other locally-embedded location types (see hasAtomicLocalGrant()) grant +
+    // animate their item the instant the player physically interacts with them - completely
+    // independent of the AP network round-trip for that same location, and atomically with the
+    // location's checked-state being updated (both happen in the same native code path, no async
+    // gap, and unaffected by the general-inventory reset wipe since that state lives in separate
+    // per-region save data). That atomicity holds regardless of wasResetPending, so this check runs
+    // unconditionally rather than being gated behind shouldDedup - gating it left chest-type items
+    // with zero dedup protection specifically during the reset-pending resync window, which is the
+    // single most likely time for a duplicate delivery to actually happen.
+    if (entry.player == AP_GetPlayerID() && hasAtomicLocalGrant(entry.location)) {
+        if (IsLocationChecked(entry.location)) {
+            ApItemLog.info("shouldSkipDuplicateItem: skipped, location {} already granted locally", entry.location);
+            return true;
+        }
+        return false;
+    }
+
+    if (!shouldDedup)
+        return false;
+
+    // Track (player, location) pairs we've actually processed, persisted so it survives
+    // reconnects, for everything else (self non-chest locations + foreign locations).
+    //
+    // Self-locations used to be deduped via IsLocationChecked() unconditionally instead, on the
+    // theory that our own save-file state is authoritative and safe to trust. That's only true for
+    // locations with a local, atomic grant like chests (handled above) - for everything else,
+    // IsLocationChecked() reflects whether the location's "checked" flag has been set (either from
+    // the AP_SetLocationCheckedCallback's SetLocationChecked() confirmation, or a live
+    // isLocationObtained() read of the location's own completion condition), not whether we've
+    // actually been granted the ITEM that location contains. For those, the server can send the
+    // LocationChecked confirmation for a location in the same instant it sends the item itself -
+    // so on the item's very first, legitimate delivery, IsLocationChecked() could already read
+    // true and this would wrongly skip granting the item, permanently losing it. That's exactly
+    // what happened to a Progressive Dominion Rod during a big multi-item burst: HandleItemReceived
+    // queued it, then the LocationChecked callback fired for the same location before Execute()
+    // drained the queue, and the old logic saw IsLocationChecked() == true and silently dropped it.
+    //
+    // AP location IDs are shared globally across every player of the same game (confirmed via
+    // the apworld's get_apid(), which is a flat base_id + code with no per-player component), so a
+    // same-numbered location can exist in both our world and another player's world - but that's
+    // fine here since the (player, location) pair disambiguates them.
+    auto& processedItems = randomizer_GetContext().mProcessedNetworkItems;
+    u64 key = RandomizerContext::EncodeNetworkItemKey(entry.player, entry.location);
+    if (processedItems.contains(key)) {
+        ApItemLog.info("shouldSkipDuplicateItem: skipped, already processed gift from player {} at location {}",
+            entry.player, entry.location);
+        return true;
+    }
+    // Persistence is batched by the caller (Execute()) after the whole drain loop, not per-item.
+    processedItems.insert(key);
+
+    return false;
 }
 
 void ArchipelagoContext::HandleResetInventory() {
@@ -569,6 +771,10 @@ void ArchipelagoContext::HandleResetInventory() {
 }
 
 void ArchipelagoContext::HandleReceiveLocationScout(const std::vector<AP_NetworkItem>& items) {
+    // Runs on the AP network thread (AP_SetLocationInfoCallback) - m_locationItemInfo is also read
+    // from the main thread every frame (Execute() and everything it calls), so this whole loop must
+    // hold m_locationInfoMutex to avoid a concurrent-mutation-during-iteration race.
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     for (const auto& item : items) {
         int parsedItemId;
         std::string parsedItemName;
@@ -596,8 +802,18 @@ void ArchipelagoContext::HandleReceiveLocationScout(const std::vector<AP_Network
             continue;
         }
 
-        bool collected = false;
-        if (instance().m_initLocationCollectState.contains(item.location))
+        // HandleReceiveLocationScout() isn't guaranteed to run exactly once - the connect modal's
+        // scout-wait loop can re-request scouts after a timeout, and if the original (merely slow,
+        // not actually lost) response then arrives late, its response arrives even later still,
+        // potentially well after gameplay has already started and this location has been checked.
+        // Blindly overwriting the map entry here would reset collected back to the stale snapshot
+        // taken at connect time, making UpdateCheckedLocations() think the location needs sending
+        // again - which is exactly what caused a Forest Temple Diababa Heart Container check to be
+        // sent to the server twice. So: only seed collected from the initial snapshot the first
+        // time we see this location; if we've already recorded progress on it, keep that.
+        auto existingIt = instance().m_locationItemInfo.find(locName);
+        bool collected = existingIt != instance().m_locationItemInfo.end() ? existingIt->second.collected : false;
+        if (existingIt == instance().m_locationItemInfo.end() && instance().m_initLocationCollectState.contains(item.location))
             collected = instance().m_initLocationCollectState[item.location];
 
         instance().m_locationItemInfo[locName] = {
@@ -613,6 +829,7 @@ void ArchipelagoContext::HandleReceiveLocationScout(const std::vector<AP_Network
 // so eventually finding a way to properly associate locations with their respective item get funcs would benefit this system
 void ArchipelagoContext::UpdateCheckedLocations() {
     auto& world = instance().m_archiWorld;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     bool changed = false;
 
@@ -652,6 +869,7 @@ void ArchipelagoContext::SetNeedUpdateLocations(bool update) {
 
 bool ArchipelagoContext::IsLocationChecked(int locId) {
     auto& world = instance().m_archiWorld;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
         if (locInfo.apLocationId == locId) {
@@ -669,6 +887,38 @@ bool ArchipelagoContext::IsLocationChecked(int locId) {
     return false;
 }
 
+bool ArchipelagoContext::hasAtomicLocalGrant(int64_t apLocationId) {
+    // The category list this checks against (RandomizerContext::kAtomicallyGrantedLocationCategories)
+    // is shared with randomizer_context.cpp's world-gen override-table population, so the two sides
+    // can't drift independently - see that constant's declaration for the full reasoning.
+    std::lock_guard<std::mutex> lock(m_locationInfoMutex);
+    for (const auto& [locName, locInfo] : m_locationItemInfo) {
+        if (locInfo.apLocationId == apLocationId) {
+            if (auto* location = m_archiWorld->GetLocation(locInfo.locationName, true)) {
+                for (const auto* category : RandomizerContext::kAtomicallyGrantedLocationCategories) {
+                    if (!location->HasCategories(category))
+                        continue;
+
+                    // World-gen only populates mShopOverrides for "Shop" locations when the
+                    // "Shop Items" setting is On (randomizer_context.cpp's world-gen loop) - if a
+                    // Shop location is tagged with the category but that setting is off, no local
+                    // override was ever embedded, so treating it as atomically-locally-granted here
+                    // would wrongly dedup via IsLocationChecked() an item that only the network
+                    // delivery actually grants, risking losing it on first delivery (the same class
+                    // of bug already hit for the Progressive Dominion Rod).
+                    if (std::string_view(category) == "Shop" && m_archiWorld->Setting("Shop Items") != "On")
+                        continue;
+
+                    return true;
+                }
+                return false;
+            }
+            return false;
+        }
+    }
+    return false;
+}
+
 void ArchipelagoContext::SetLocationChecked(int locId, bool collected) {
     // func was ran before location scouts could be sent out, cache result until scouts return.
     if (!IsReceivedLocationScouts()) {
@@ -677,6 +927,7 @@ void ArchipelagoContext::SetLocationChecked(int locId, bool collected) {
     }
 
     auto& world = instance().m_archiWorld;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     for (auto& [locName, locInfo] : instance().m_locationItemInfo) {
         if (locInfo.apLocationId == locId) {
@@ -697,6 +948,7 @@ void ArchipelagoContext::SetLocationChecked(int locId, bool collected) {
 
 void ArchipelagoContext::UpdateLocationState(int locId, bool collected) {
     auto& world = instance().m_archiWorld;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
         if (locInfo.apLocationId == locId) {
@@ -714,6 +966,7 @@ void ArchipelagoContext::UpdateLocationState(int locId, bool collected) {
 
 void ArchipelagoContext::UpdateAllLocationState() {
     auto& world = instance().m_archiWorld;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     // TODO: find out why some locations seem to keep their collection state upon reset (bugs)
 
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
@@ -726,6 +979,7 @@ void ArchipelagoContext::UpdateAllLocationState() {
 }
 
 bool ArchipelagoContext::IsReceivedLocationScouts() {
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     return !instance().m_locationItemInfo.empty();
 }
 
@@ -750,6 +1004,7 @@ void ArchipelagoContext::RequestAllLocationScout(bool isHint) {
         locations.insert(ARCHI_ITEM_OFFSET + i);
     }
 
+    DuskLog.info("Requesting location scouts for {} locations.", locations.size());
     AP_SendLocationScouts(locations, isHint);
 }
 
@@ -762,8 +1017,8 @@ bool ArchipelagoContext::GenerateConfigFromAP(randomizer::seedgen::config::Confi
     YAML::Node apConfigYaml;
     try {
         apConfigYaml = YAML::Load(settingsStr);
-    }catch (YAML::BadFile& e) {
-        DuskLog.warn("Failed to load AP Config YAML file!");
+    }catch (const YAML::Exception& e) {
+        DuskLog.warn("Failed to load AP Config YAML file! Reason: {}", e.what());
         return false;
     }
 
@@ -777,44 +1032,50 @@ bool ArchipelagoContext::GenerateConfigFromAP(randomizer::seedgen::config::Confi
 
         const auto& settingConvert = GetAPSettingNameConvert(apSettingName);
 
-        if (!settingConvert.apName.empty()) {
-            auto& setting = settings.GetMap().at(settingConvert.dusklightName);
-            setting.SetCurrentOption(settingConvert.tryGetOptionConvert(apSettingValue));
-        } else if (apSettingName == "Castle Requirements") {
-            auto& setting = settings.GetMap().at("Hyrule Barrier Requirements");
+        //try catch is neccesary here. If it fails on converting the setting, it will crash and not continue reading the settings.
+        //this results in it using a default settiings file instead of the settings for the player
+        try {
+            if (!settingConvert.apName.empty()) {
+                auto& setting = settings.GetMap().at(settingConvert.dusklightName);
+                setting.SetCurrentOption(settingConvert.tryGetOptionConvert(apSettingValue));
+            } else if (apSettingName == "Castle Requirements") {
+                auto& setting = settings.GetMap().at("Hyrule Barrier Requirements");
 
-            // ap assumes max mirror shards/fused shadows/dungeons, so update those settings as well
+                // ap assumes max mirror shards/fused shadows/dungeons, so update those settings as well
 
-            if(apSettingValue == "Open")
-                setting.SetCurrentOption("Open");
-            else if(apSettingValue == "Vanilla")
-                setting.SetCurrentOption("Vanilla");
-            else if(apSettingValue == "Fused Shadows") {
-                setting.SetCurrentOption("Fused Shadows");
-                settings.GetMap().at("Hyrule Barrier Fused Shadows").SetCurrentOption("3");
-            }else if(apSettingValue == "Mirror Shards") {
-                setting.SetCurrentOption("Mirror Shards");
-                settings.GetMap().at("Hyrule Barrier Mirror Shards").SetCurrentOption("4");
-            }else if(apSettingValue == "All Dungeons") {
-                setting.SetCurrentOption("Dungeons");
-                settings.GetMap().at("Hyrule Barrier Dungeons").SetCurrentOption("8");
+                if(apSettingValue == "Open")
+                    setting.SetCurrentOption("Open");
+                else if(apSettingValue == "Vanilla")
+                    setting.SetCurrentOption("Vanilla");
+                else if(apSettingValue == "Fused Shadows") {
+                    setting.SetCurrentOption("Fused Shadows");
+                    settings.GetMap().at("Hyrule Barrier Fused Shadows").SetCurrentOption("3");
+                }else if(apSettingValue == "Mirror Shards") {
+                    setting.SetCurrentOption("Mirror Shards");
+                    settings.GetMap().at("Hyrule Barrier Mirror Shards").SetCurrentOption("4");
+                }else if(apSettingValue == "All Dungeons") {
+                    setting.SetCurrentOption("Dungeons");
+                    settings.GetMap().at("Hyrule Barrier Dungeons").SetCurrentOption("8");
+                }
+            }else if (apSettingName == "Temple of Time Entrance Requirements") {
+                auto& setting = settings.GetMap().at("Sacred Grove Does Not Require Skull Kid");
+                auto& setting2 = settings.GetMap().at("Temple of Time Sword Requirement");
+
+                if(apSettingValue == "Closed") {
+                    setting.SetCurrentOption("Off");
+                    setting2.SetCurrentOption("Master Sword");
+                }else if (apSettingValue == "Open Grove") {
+                    setting.SetCurrentOption("On");
+                    setting2.SetCurrentOption("Master Sword");
+                }else if (apSettingValue == "Open") {
+                    setting.SetCurrentOption("On");
+                    setting2.SetCurrentOption("None");
+                }
+            }else {
+                DuskLog.debug("Missing Setting: {} Value: {}", apSettingName, apSettingValue);
             }
-        }else if (apSettingName == "Temple of Time Entrance Requirements") {
-            auto& setting = settings.GetMap().at("Sacred Grove Does Not Require Skull Kid");
-            auto& setting2 = settings.GetMap().at("Temple of Time Sword Requirement");
-
-            if(apSettingValue == "Closed") {
-                setting.SetCurrentOption("Off");
-                setting2.SetCurrentOption("Master Sword");
-            }else if (apSettingValue == "Open Grove") {
-                setting.SetCurrentOption("On");
-                setting2.SetCurrentOption("Master Sword");
-            }else if (apSettingValue == "Open") {
-                setting.SetCurrentOption("On");
-                setting2.SetCurrentOption("None");
-            }
-        }else {
-            DuskLog.debug("Missing Setting: {} Value: {}", apSettingName, apSettingValue);
+        }catch (const std::exception& e) {
+            DuskLog.warn("Failed to apply AP setting \"{}\" (value \"{}\"): {}", apSettingName, apSettingValue, e.what());
         }
     }
 
@@ -822,6 +1083,7 @@ bool ArchipelagoContext::GenerateConfigFromAP(randomizer::seedgen::config::Confi
 }
 
 int ArchipelagoContext::GetItemAtLocation(const std::string& locName) {
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     if (!instance().m_locationItemInfo.contains(locName)) {
         DuskLog.warn("No item found for ({}).", locName);
         return 0;
@@ -830,6 +1092,7 @@ int ArchipelagoContext::GetItemAtLocation(const std::string& locName) {
 }
 
 int ArchipelagoContext::GetItemAtLocation(int locId) {
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
     for (const auto& [locName, locInfo] : instance().m_locationItemInfo) {
         if (locInfo.apLocationId == locId) {
             return locInfo.itemId;
@@ -857,6 +1120,7 @@ void ArchipelagoContext::FillArchipelagoWorld() {
     }
 
     auto& locationInfo = instance().m_locationItemInfo;
+    std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
     // fill all locations with data pulled from archi session
     for (auto location : world->GetAllLocations()) {

--- a/src/dusk/archipelago/archipelago_context.cpp
+++ b/src/dusk/archipelago/archipelago_context.cpp
@@ -2,10 +2,12 @@
 
 #include <array>
 #include <thread>
+#include <unordered_map>
 
 #include "Archipelago.h"
 #include "d/d_com_inf_game.h"
 #include "d/d_item.h"
+#include "d/d_map_path_dmap.h"
 #include "d/actor/d_a_alink.h"
 #include "dusk/config.hpp"
 #include "dusk/logging.h"
@@ -111,6 +113,214 @@ ArchipelagoContext& instance() {
     static ArchipelagoContext instance;
     return instance;
 }
+
+// Stage code -> display name, mirroring the apworld's ClientUtils.py STAGE_TO_NAME. poptracker's
+// autotracking keys off these exact strings, so keep it in sync with the apworld client.
+static const std::unordered_map<std::string, std::string> sStageCodeToName = {
+    {"D_MN01", "Lakebed Temple"},
+    {"D_MN04", "Goron Mines"},
+    {"D_MN05", "Forest Temple"},
+    {"D_MN06", "Temple of Time"},
+    {"D_MN07", "City in the Sky"},
+    {"D_MN08", "Palace of Twilight"},
+    {"D_MN09", "Hyrule Castle"},
+    {"D_MN10", "Arbiter's Grounds"},
+    {"D_MN11", "Snowpeak Ruins"},
+    {"D_SB00", "Ice Block Cave"},
+    {"D_SB01", "Cave or Ordeals"},
+    {"D_SB02", "Kakariko Gorge Lantern Cave"},
+    {"D_SB03", "Lake Hylia Lantern Cave"},
+    {"D_SB04", "Goron Stockcave"},
+    {"D_SB05", "Grotto 1"},
+    {"D_SB06", "Grotto 2"},
+    {"D_SB07", "Grotto 3"},
+    {"D_SB08", "Grotto 4"},
+    {"D_SB09", "Grotto 5"},
+    {"D_SB10", "Faron Woods Cave"},
+    {"F_SP00", "Ordon Ranch"},
+    {"F_SP102", "Title Screen"},
+    {"F_SP103", "Ordon Village"},
+    {"F_SP104", "Ordon Spring"},
+    {"F_SP108", "Faron Woods"},
+    {"F_SP109", "Kakariko Village"},
+    {"F_SP110", "Death Mountain"},
+    {"F_SP111", "Kakariko Graveyard"},
+    {"F_SP112", "Zora's River"},
+    {"F_SP113", "Zora's Domain"},
+    {"F_SP114", "Snowpeak"},
+    {"F_SP115", "Lake Hylia"},
+    {"F_SP116", "Hyrule Castle Town"},
+    {"F_SP117", "Sacred Grove"},
+    {"F_SP118", "Bulblin Camp"},
+    {"F_SP121", "Hyrule Field"},
+    {"F_SP122", "Castle Town Fields"},
+    {"F_SP123", "King Bulbin Fights"},
+    {"F_SP124", "Gerudo Desert"},
+    {"F_SP125", "Mirror Chamber"},
+    {"F_SP126", "Upper Zora's River"},
+    {"F_SP127", "Fishing Pond"},
+    {"F_SP128", "Hidden Village"},
+    {"F_SP200", "Shade's Realm"},
+    {"R_SP01", "Ordon Interiors"},
+    {"R_SP107", "Sewers"},
+    {"R_SP108", "Coro's Lantern Shop"},
+    {"R_SP109", "Kakriko Interiors"},
+    {"R_SP110", "Death Mountain Sumo Hall"},
+    {"R_SP116", "Hyrule Castle Town Interiors (Telma's bar)"},
+    {"R_SP127", "Hena's Cabin"},
+    {"R_SP128", "Impaz's House"},
+    {"R_SP160", "Hyrule Castle Town Interiors (Jovani, Agitha, Shops, etc)"},
+    {"R_SP161", "Star Tent"},
+    {"R_SP209", "Sanctuary Basement"},
+    {"R_SP300", "Light Arrow cutscenes"},
+    {"R_SP301", "Hyrule Castle cutscenes"},
+    {"S_MV000", "Deleted"},
+};
+
+// Reads the null-or-length-terminated 8 byte stage code out of the live game state.
+static std::string ReadCurrentStageCode() {
+    const char* raw = dComIfGp_getStartStageName();
+    std::string code;
+    for (int i = 0; i < 8 && raw[i] != '\0'; ++i) {
+        code.push_back(raw[i]);
+    }
+    return code;
+}
+
+// Resolves a raw stage code to its AP display name, or nullptr if unknown. Dungeon boss-room
+// sub-stages ("D_MN01A") are folded to the base 6-char dungeon code first, as ClientUtils.py does.
+static const std::string* ResolveStageName(std::string stageCode) {
+    if (stageCode.rfind("D_MN", 0) == 0 && stageCode.size() > 6) {
+        stageCode.resize(6);
+    }
+
+    auto it = sStageCodeToName.find(stageCode);
+    if (it == sStageCodeToName.end())
+        return nullptr;
+    return &it->second;
+}
+
+static std::string ToJsonStringLiteral(const std::string& value) {
+    std::string out = "\"";
+    for (char c : value) {
+        if (c == '"' || c == '\\')
+            out.push_back('\\');
+        out.push_back(c);
+    }
+    out.push_back('"');
+    return out;
+}
+
+static void SetTrackedIntDataStorage(const std::string& key, int value, int defaultValue) {
+    AP_SetServerDataRequest request;
+    request.key = key;
+    request.type = AP_DataType::Int;
+    request.want_reply = false;
+    request.default_value = &defaultValue;
+    AP_DataStorageOperation replaceOp;
+    replaceOp.operation = "replace";
+    replaceOp.value = &value;
+    request.operations = {replaceOp};
+    AP_BulkSetServerData(&request);
+}
+
+static void SetTrackedStringDataStorage(const std::string& key, const std::string& value, const std::string& defaultValue) {
+    AP_SetServerDataRequest request;
+    request.key = key;
+    request.type = AP_DataType::Raw;
+    request.want_reply = false;
+    std::string jsonDefault = ToJsonStringLiteral(defaultValue);
+    request.default_value = &jsonDefault;
+    std::string jsonValue = ToJsonStringLiteral(value);
+    AP_DataStorageOperation replaceOp;
+    replaceOp.operation = "replace";
+    replaceOp.value = &jsonValue;
+    request.operations = {replaceOp};
+    AP_BulkSetServerData(&request);
+}
+
+// Sent as bare JSON literals (true/false), not JSON strings, matching the apworld client and what
+// poptracker's autotracking expects.
+static void SetTrackedBoolDataStorage(const std::string& key, bool value, bool defaultValue) {
+    AP_SetServerDataRequest request;
+    request.key = key;
+    request.type = AP_DataType::Raw;
+    request.want_reply = false;
+    std::string jsonDefault = defaultValue ? "true" : "false";
+    request.default_value = &jsonDefault;
+    std::string jsonValue = value ? "true" : "false";
+    AP_DataStorageOperation replaceOp;
+    replaceOp.operation = "replace";
+    replaceOp.value = &jsonValue;
+    request.operations = {replaceOp};
+    AP_BulkSetServerData(&request);
+}
+
+// Howling Stones: byte+bitmask offsets into dComIfGs_getSaveInfo(), from the apworld's
+// ClientUtils.py. Scents/quest-items/Memory Reward don't read correctly this way on this build;
+// they use sEventBitTrackingEntries below instead.
+struct FlagTrackingEntry {
+    const char* key;
+    std::size_t offset;
+    u8 mask;
+};
+
+static const std::array<FlagTrackingEntry, 6> sFlagTrackingEntries = {{
+    {"Death Mountain Stone", 0x82A, 0x80},
+    {"Zora River Stone", 0x82A, 0x40},
+    {"Sacred Grove Stone", 0x82A, 0x20},
+    {"Lake Hylia Stone", 0x82A, 0x10},
+    {"Snowpeak Stone", 0x82A, 0x8},
+    {"Hidden Village Stone", 0x82A, 0x4},
+}};
+
+static bool ReadSaveInfoFlag(std::size_t offset, u8 mask) {
+    auto* base = reinterpret_cast<const u8*>(dComIfGs_getSaveInfo());
+    return (base[offset] & mask) != 0;
+}
+
+// Scents/quest-items/Memory Reward, read via dComIfGs_isEventBit(rawFlagValue). Most values are
+// cross-checked against randomizer/generator/data/startflags.yaml; "Youth Scent", "Ilias Scent"
+// and "Memory Reward" are inferred from d_save_bit_labels.inc and lower-confidence.
+struct EventBitTrackingEntry {
+    const char* key;
+    u16 flagValue;
+};
+
+static const std::array<EventBitTrackingEntry, 10> sEventBitTrackingEntries = {{
+    {"Youth Scent", 0x2240},
+    {"Ilias Scent", 0x2220},
+    {"Medicine Scent", 0x2F04},
+    {"ReekFish Scent", 0x6120},
+    {"Poe Scent", 0x6210},
+    {"Renados letter", 0x0F80},
+    {"Telmas Invoice", 0x2710},
+    {"Wooden Statue", 0x2204},
+    {"Ilias Charm", 0x2280},
+    {"Memory Reward", 0x2320},
+}};
+
+static bool ReadEventBit(u16 flagValue) {
+    return dComIfGs_isEventBit(flagValue) != 0;
+}
+
+// The 8 boss-defeated keys. clearFlagValue is the vanilla dungeon-clear event bit, which
+// UpdateFlagTrackingData() reads (see the note there).
+struct BossTrackingEntry {
+    const char* key;
+    u16 clearFlagValue;
+};
+
+static const std::array<BossTrackingEntry, 8> sBossTrackingEntries = {{
+    {"Diababa Defeated", 0x0602},
+    {"Fyrus Defeated", 0x0701},
+    {"Morpheel Defeated", 0x0904},
+    {"Stallord Defeated", 0x2010},
+    {"Blizzeta Defeated", 0x2008},
+    {"Armogohma Defeated", 0x2004},
+    {"Argorok Defeated", 0x2002},
+    {"Zant Defeated", 0x4680},
+}};
 
 const SettingsNameConvert& GetAPSettingNameConvert(const std::string& apSettingName) {
     for (const auto& entry : sArchiSettingToDusklight) {
@@ -364,8 +574,9 @@ std::string ArchipelagoContext::GetArchipelagoSeedName() {
 }
 
 void ArchipelagoContext::GetSeedDirectoryPath(std::filesystem::path& outPath) {
-    if (IsConnected()) {
-        auto& roomInfo = instance().m_roomInfo;
+    // Also require IsRoomInfoReady(): with an empty seed_name this would resolve to "archipelago/AP_",
+    // a bogus directory with no dedup history. Leaving outPath untouched makes that visible to callers.
+    if (IsConnected() && IsRoomInfoReady()) {
         outPath = ui::GetRandomizerPath() / "archipelago" / GetArchipelagoSeedName();
     }
 }
@@ -398,6 +609,13 @@ bool ArchipelagoContext::ConnectToServer(int file, bool isBlocking) {
         std::lock_guard<std::mutex> lock(instance().m_queueMutex);
         instance().m_receivedItemsQueue.clear();
     }
+
+    // Reset the tracking-data "last sent" caches so the new connection resends a full set.
+    instance().m_lastSentStageName.clear();
+    instance().m_lastSentRoom = std::numeric_limits<int>::min();
+    instance().m_lastSentFloor = std::numeric_limits<int>::min();
+    instance().m_lastSentLayer = std::numeric_limits<int>::min();
+    instance().m_lastSentFlags.clear();
 
     instance().LoadTempItemInfo();
 
@@ -481,6 +699,10 @@ bool ArchipelagoContext::IsConnected() {
     return status == AP_ConnectionStatus::Connected || status == AP_ConnectionStatus::Authenticated;
 }
 
+bool ArchipelagoContext::IsRoomInfoReady() {
+    return !instance().m_roomInfo.seed_name.empty();
+}
+
 void ArchipelagoContext::MessageThreadFunc() {
     DuskLog.info("AP Thread started.");
 
@@ -498,9 +720,87 @@ void ArchipelagoContext::MessageThreadFunc() {
     DuskLog.info("AP Thread ended.");
 }
 
+void ArchipelagoContext::UpdateMapTrackingData() {
+    // Team is hardcoded to 0 (AP doesn't use multiple teams yet; matches poptracker's fallback).
+    const int team = 0;
+    const int slot = AP_GetPlayerID();
+    const std::string keyPrefix = "TP_" + std::to_string(team) + "_" + std::to_string(slot) + "_";
+
+    std::string stageCode = ReadCurrentStageCode();
+    const std::string* stageName = ResolveStageName(stageCode);
+    if (!stageName) {
+        DuskLog.warn("UpdateMapTrackingData: unrecognized stage code '{}', not sending Current Stage update", stageCode);
+    } else if (*stageName != instance().m_lastSentStageName) {
+        SetTrackedStringDataStorage(keyPrefix + "Current Stage", *stageName, "Menu");
+        instance().m_lastSentStageName = *stageName;
+    }
+
+    int room = dStage_roomControl_c::getStayNo();
+    if (room != instance().m_lastSentRoom) {
+        SetTrackedIntDataStorage(keyPrefix + "Current Room", room, -1);
+        instance().m_lastSentRoom = room;
+    }
+
+    // Send the raw unsigned byte (basements wrap to 255/254/253), matching the apworld's client.
+    int floor = static_cast<u8>(dMapInfo_c::mNowStayFloorNo);
+    if (floor != instance().m_lastSentFloor) {
+        SetTrackedIntDataStorage(keyPrefix + "Current Floor", floor, -1);
+        instance().m_lastSentFloor = floor;
+    }
+
+    int layer = dComIfGp_getStartStageLayer();
+    if (layer != instance().m_lastSentLayer) {
+        SetTrackedIntDataStorage(keyPrefix + "Current Layer", layer, -1);
+        instance().m_lastSentLayer = layer;
+    }
+
+    AP_CommitServerData();
+}
+
+void ArchipelagoContext::UpdateFlagTrackingData() {
+    // See UpdateMapTrackingData() for why team is hardcoded to 0.
+    const int team = 0;
+    const int slot = AP_GetPlayerID();
+    const std::string keyPrefix = "TP_" + std::to_string(team) + "_" + std::to_string(slot) + "_";
+
+    for (const auto& entry : sFlagTrackingEntries) {
+        bool value = ReadSaveInfoFlag(entry.offset, entry.mask);
+        auto it = instance().m_lastSentFlags.find(entry.key);
+        if (it != instance().m_lastSentFlags.end() && it->second == value)
+            continue;
+        SetTrackedBoolDataStorage(keyPrefix + entry.key, value, false);
+        instance().m_lastSentFlags[entry.key] = value;
+    }
+
+    for (const auto& entry : sEventBitTrackingEntries) {
+        bool value = ReadEventBit(entry.flagValue);
+        auto it = instance().m_lastSentFlags.find(entry.key);
+        if (it != instance().m_lastSentFlags.end() && it->second == value)
+            continue;
+        SetTrackedBoolDataStorage(keyPrefix + entry.key, value, false);
+        instance().m_lastSentFlags[entry.key] = value;
+    }
+
+    // Boss-defeated state comes from the dungeon-clear event bit; dComIfGs_isStageBossEnemy()
+    // reads false for bosses in dungeons other than the one you're currently in.
+    for (const auto& entry : sBossTrackingEntries) {
+        bool defeated = ReadEventBit(entry.clearFlagValue);
+        auto it = instance().m_lastSentFlags.find(entry.key);
+        if (it != instance().m_lastSentFlags.end() && it->second == defeated)
+            continue;
+        SetTrackedBoolDataStorage(keyPrefix + entry.key, defeated, false);
+        instance().m_lastSentFlags[entry.key] = defeated;
+    }
+
+    AP_CommitServerData();
+}
+
 void ArchipelagoContext::Execute() {
     if (!IsConnected())
         return;
+
+    UpdateMapTrackingData();
+    UpdateFlagTrackingData();
 
     // backfill the per-species "Misc." flag for any golden bugs already obtained before this fix
     // existed, so previously-received bugs are picked up by Agitha/the bug menu without needing to
@@ -558,8 +858,15 @@ void ArchipelagoContext::Execute() {
 
     // update location checks here if we need to
     if (instance().m_isUpdateLocations) {
-        UpdateCheckedLocations();
+        UpdateCheckedLocations(true);
         instance().m_isUpdateLocations = false;
+        instance().m_locationRescanTimer = 0;
+    }
+    // ~1s backstop for checks whose flag is set outside execItemGet() (AG poe soul pulls, Agitha
+    // bug rewards). Re-reads the real game flags, so it's independent of how the flag was set.
+    else if (IsReceivedLocationScouts() && ++instance().m_locationRescanTimer >= 60) {
+        instance().m_locationRescanTimer = 0;
+        UpdateCheckedLocations();
     }
 }
 
@@ -629,27 +936,24 @@ bool ArchipelagoContext::shouldSkipDuplicateItem(const ReceivedItemEntry& entry)
     // always be deduped, reset or not; everything else keeps the original reset-bypass behavior,
     // since re-granting equipment/one-off items after the wipe is harmless.
     //
-    // Progressive Sky Book (AP id 123) has the exact same problem despite looking flag-gated at the
-    // top level: getProgressiveSkybook() resolves every receive after the first two into "Air Letter",
-    // which does the same unconditional dComIfGs_setAncientDocumentNum(letterCount + 1) with no
-    // "already counted" check - so it's just as vulnerable to replay-induced over-counting as keys.
-    //
-    // Piece of Heart / Heart Container (AP ids 23/24) are the same shape of bug: item_func_KAKERA_HEART/
-    // UTUWA_HEART call dComIfGp_setItemMaxLifeCount(), which does an unconditional mItemMaxLifeCount +=
-    // max - re-processing one of these on replay permanently inflates max health.
+    // Piece of Heart/Heart Container and Progressive Sky Book also lack an "already counted" guard,
+    // but unlike keys their backing state IS wiped by HandleResetInventory(), so replaying their
+    // full history against the wiped baseline reconstructs the correct total. Deduping them
+    // permanently would instead lose them after a reset (observed with Progressive Sky Book).
     const bool isSmallKeyItem = (entry.relativeId >= 54 && entry.relativeId <= 62) || entry.relativeId == 66;
-    const bool isSkyBookItem = entry.relativeId == 123;
-    const bool isHeartItem = entry.relativeId == 23 || entry.relativeId == 24;
-    const bool isNonIdempotentCounter = isSmallKeyItem || isSkyBookItem || isHeartItem;
 
-    // Items delivered with no location (AP's "precollected"/start-inventory items, which the
-    // pre-existing `netItem.location != -1` check this replaced already anticipated as a real,
-    // expected value) can't use any location-based dedup at all. For ordinary items that's fine -
-    // re-granting an idempotent item is harmless - but the non-idempotent counters above still need
-    // *some* persistent dedup, or a location-less key/skybook/heart delivery would replay and
-    // over-count on every single reconnect with zero protection. Dedup those via (player,
-    // relativeId) instead, in a key range (bit 47 set) that can never collide with a real
-    // apLocationId, which this codebase's location ids never approach.
+    // Ice Trap (AP id 131) has no backing state at all: its freeze effect already played and
+    // HandleResetInventory() can't wipe it, so a processed trap must stay deduped, reset or not, or
+    // every reconnect resync stacks another freeze. Dedup below is keyed by (player, location), so
+    // each distinct trap still fires once.
+    const bool isIceTrap = entry.relativeId == 131;
+
+    const bool isNonIdempotentCounter = isSmallKeyItem || isIceTrap;
+
+    // Location-less items (AP precollected/start-inventory) can't use location-based dedup. That's
+    // harmless for idempotent items, but a location-less key would over-count on every reconnect,
+    // so dedup those via (player, relativeId) in a key range (bit 47 set) that can't collide with
+    // a real apLocationId.
     if (entry.location == -1) {
         if (!isNonIdempotentCounter)
             return false;
@@ -742,6 +1046,10 @@ void ArchipelagoContext::HandleResetInventory() {
     // reset collect (poes, shards, swords)
     playerInfo.getCollect().init();
 
+    // The above don't touch the Sky Book letter count; zero it too so its replay (see
+    // shouldSkipDuplicateItem()) starts from a clean baseline.
+    dComIfGs_setAncientDocumentNum(0);
+
     playerInfo.getPlayerStatusA().setMaxLife(15);
     playerInfo.getPlayerStatusA().setWalletSize(WALLET);
     // dont reset rupees, and instead reject rupee updates while refilling inv
@@ -829,7 +1137,7 @@ void ArchipelagoContext::HandleReceiveLocationScout(const std::vector<AP_Network
 }
 // TODO: atm this is a sort of lazy solution to not having direct access to what location was checked when an execItemGet is called
 // so eventually finding a way to properly associate locations with their respective item get funcs would benefit this system
-void ArchipelagoContext::UpdateCheckedLocations() {
+void ArchipelagoContext::UpdateCheckedLocations(bool warnIfNoChange) {
     auto& world = instance().m_archiWorld;
     std::lock_guard<std::mutex> lock(instance().m_locationInfoMutex);
 
@@ -859,7 +1167,7 @@ void ArchipelagoContext::UpdateCheckedLocations() {
         }
     }
 
-    if (!changed) {
+    if (!changed && warnIfNoChange) {
         DuskLog.warn("No locations had any changes! this might not be normal.");
     }
 }
@@ -1198,6 +1506,12 @@ void ArchipelagoContext::GenerateLocalWorldData() {
     std::filesystem::path workingDir;
 
     GetSeedDirectoryPath(workingDir);
+
+    if (workingDir.empty()) {
+        DuskLog.fatal("GenerateLocalWorldData: seed directory path is empty (Room Info not "
+            "received yet) - aborting world data generation instead of using a bogus directory.");
+        return;
+    }
 
     if (std::filesystem::exists(workingDir)) {
         instance().m_config.LoadFromFile(workingDir / "settings.yaml", workingDir / "preferences.yaml");

--- a/src/dusk/archipelago/archipelago_context.cpp
+++ b/src/dusk/archipelago/archipelago_context.cpp
@@ -673,17 +673,19 @@ bool ArchipelagoContext::shouldSkipDuplicateItem(const ReceivedItemEntry& entry)
     // would make this condition always true and change behavior for non-counter items.
     const bool shouldDedup = isNonIdempotentCounter || !entry.wasResetPending;
 
-    // Chests and the other locally-embedded location types (see hasAtomicLocalGrant()) grant +
-    // animate their item the instant the player physically interacts with them - completely
-    // independent of the AP network round-trip for that same location, and atomically with the
-    // location's checked-state being updated (both happen in the same native code path, no async
-    // gap, and unaffected by the general-inventory reset wipe since that state lives in separate
-    // per-region save data). That atomicity holds regardless of wasResetPending, so this check runs
-    // unconditionally rather than being gated behind shouldDedup - gating it left chest-type items
-    // with zero dedup protection specifically during the reset-pending resync window, which is the
-    // single most likely time for a duplicate delivery to actually happen.
-    if (entry.player == AP_GetPlayerID() && hasAtomicLocalGrant(entry.location)) {
+    // Chests etc. grant their item locally the instant the player interacts with them, so the
+    // network copy is normally redundant and safe to skip once IsLocationChecked() is true. But
+    // that "checked" flag survives HandleResetInventory()'s wipe while the actual item (inventory
+    // slot, collect flag, ...) doesn't - so during a reset resync, trusting it here means the item
+    // never comes back. Only skip outside of a reset; during one, fall through to the general dedup
+    // below so the item gets re-granted like everything else.
+    if (entry.player == AP_GetPlayerID() && hasAtomicLocalGrant(entry.location) && !entry.wasResetPending) {
         if (IsLocationChecked(entry.location)) {
+            // Also seed the persisted dedup table, so a later reset resync (which can't use
+            // IsLocationChecked() - see above) still knows this was handled, and doesn't
+            // double-grant a non-idempotent counter (e.g. a small key found in a chest).
+            randomizer_GetContext().mProcessedNetworkItems.insert(
+                RandomizerContext::EncodeNetworkItemKey(entry.player, entry.location));
             ApItemLog.info("shouldSkipDuplicateItem: skipped, location {} already granted locally", entry.location);
             return true;
         }

--- a/src/dusk/archipelago/archipelago_context.hpp
+++ b/src/dusk/archipelago/archipelago_context.hpp
@@ -28,8 +28,29 @@ namespace dusk::archi
             bool collected = false;
         };
 
-        std::vector<std::pair<int, bool>> m_receivedItemsQueue;
+        struct ReceivedItemEntry {
+            int relativeId;
+            bool notify;
+            int player;
+            int64_t location;
+            bool wasResetPending;
+        };
+
+        // Lock ordering: if a caller needs both, always acquire m_queueMutex before
+        // m_locationInfoMutex (Execute()'s drain does this via IsReceivedLocationScouts()). No path
+        // currently acquires them in the reverse order - keep it that way, or this becomes a
+        // lock-order-inversion deadlock risk.
+        std::vector<ReceivedItemEntry> m_receivedItemsQueue;
         std::mutex m_queueMutex;
+
+        // Guards m_locationItemInfo: HandleReceiveLocationScout() mutates it from the AP network
+        // thread (via AP_SetLocationInfoCallback), while Execute() and everything it calls
+        // (hasAtomicLocalGrant, IsLocationChecked, UpdateCheckedLocations, etc.) reads/mutates it
+        // from the main thread every frame. Plain mutex is sufficient - traced every locking
+        // function below and none call another while already holding this lock, and AP_SendItem()
+        // (called from UpdateCheckedLocations while holding it) only queues a websocket send with
+        // no synchronous callback re-entry into this code.
+        std::mutex m_locationInfoMutex;
 
         // Rando Data
         randomizer::seedgen::config::Config m_config;
@@ -56,6 +77,12 @@ namespace dusk::archi
         void LoadTempLocationInfo();
 
         void itemRecvImpl(int id, bool notify);
+
+        bool shouldSkipDuplicateItem(const ReceivedItemEntry& entry);
+
+        void persistProcessedItems();
+
+        bool hasAtomicLocalGrant(int64_t apLocationId);
 
         int getItemIdFromApId(int apId);
 

--- a/src/dusk/archipelago/archipelago_context.hpp
+++ b/src/dusk/archipelago/archipelago_context.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <limits>
 #include <mutex>
 #include <string>
 
@@ -60,6 +61,10 @@ namespace dusk::archi
         bool m_isAllowUpdateLocations = false;
         bool m_isEnableDeathLink = false;
 
+        // Frame counter for the periodic UpdateCheckedLocations() backstop in Execute(), for checks
+        // whose flag is set outside execItemGet() (AG poe soul pulls, Agitha bug rewards).
+        int m_locationRescanTimer = 0;
+
         // AP Data
         std::unordered_map<std::string, GameLocationInfo> m_locationItemInfo;
         std::map<int, bool> m_initLocationCollectState;
@@ -89,6 +94,24 @@ namespace dusk::archi
         std::string getLocationNameFromApId(int apId) const;
 
         bool tryKillPlayer();
+
+        // Push the "TP_{team}_{slot}_Current Stage/Room/Floor/Layer" datastorage keys that
+        // poptracker's autotracking reads for map tabs. Only sends keys whose value changed.
+        static void UpdateMapTrackingData();
+
+        // Push the scent/quest-item/howling-stone/memory-reward and 8 boss-defeated datastorage
+        // keys that poptracker's autotracking reads. Only sends keys whose value changed.
+        static void UpdateFlagTrackingData();
+
+        // Last values sent by UpdateMapTrackingData(); sentinel-initialized so the first call
+        // after connecting sends a full set.
+        std::string m_lastSentStageName;
+        int m_lastSentRoom = std::numeric_limits<int>::min();
+        int m_lastSentFloor = std::numeric_limits<int>::min();
+        int m_lastSentLayer = std::numeric_limits<int>::min();
+
+        // Last values sent by UpdateFlagTrackingData(), keyed by AP key name.
+        std::unordered_map<std::string, bool> m_lastSentFlags;
     public:
         ArchipelagoContext();
 
@@ -118,6 +141,10 @@ namespace dusk::archi
 
         static bool IsConnected();
 
+        // True once seed_name has arrived (filled asynchronously after connect). Callers that need
+        // the seed directory must wait for this, not just IsConnected().
+        static bool IsRoomInfoReady();
+
         // State Handlers
 
         static void MessageThreadFunc();
@@ -130,7 +157,7 @@ namespace dusk::archi
 
         static void HandleReceiveLocationScout(const std::vector<AP_NetworkItem>& items);
 
-        static void UpdateCheckedLocations();
+        static void UpdateCheckedLocations(bool warnIfNoChange = false);
 
         static void SetNeedUpdateLocations(bool update);
 

--- a/src/dusk/autosave.cpp
+++ b/src/dusk/autosave.cpp
@@ -53,10 +53,15 @@ bool writeAutoSave() {
     dComIfGs_setMemoryToCard(mSaveBuffer, dComIfGs_getDataNum());
     mDoMemCdRWm_SetCheckSumGameData(mSaveBuffer, dComIfGs_getDataNum());
 
-    // Save randomizer hash
-    dusk::getSettings().randomizer.seedHashes[dComIfGs_getDataNum()].setValue(randomizer_GetContext().mHash);
-    dusk::config::Save();
+    // Save randomizer hash. Only do this while the randomizer is actually active (which already
+    // requires a non-empty hash) - this used to run unconditionally, so if randomizer_GetContext()
+    // ever got reset to a blank context for any reason (e.g. a failed/interrupted Archipelago
+    // reconnect) while a file kept autosaving, the next autosave would silently overwrite that
+    // file's stored seed hash with an empty string, permanently unlinking it from its Archipelago
+    // session with no way to recover other than reconnecting fresh and losing the association.
     if (randomizer_IsActive()) {
+        dusk::getSettings().randomizer.seedHashes[dComIfGs_getDataNum()].setValue(randomizer_GetContext().mHash);
+        dusk::config::Save();
         g_randomizerState.mFileNum = dComIfGs_getDataNum();
     }
 

--- a/src/dusk/imgui/ImGuiConsole.cpp
+++ b/src/dusk/imgui/ImGuiConsole.cpp
@@ -53,7 +53,7 @@ ImGuiWindow* FindDragScrollWindow(ImGuiWindow* window) {
 }  // namespace
 
 namespace dusk {
-    float ImGuiScale() { return 1.0f; }
+    float ImGuiScale() { return getSettings().game.debugUIScale.getValue(); }
 
     void ImGuiStringViewText(std::string_view text) {
         // begin()/end() do not work on MSVC
@@ -250,6 +250,8 @@ namespace dusk {
         ZoneScoped;
 
         UpdateSettings();
+
+        ImGui::GetIO().FontGlobalScale = ImGuiEngine::baseFontScale * ImGuiScale();
 
         if (ImGui::IsKeyPressed(ImGuiKey_F11)) {
             getSettings().video.enableFullscreen.setValue(!getSettings().video.enableFullscreen);

--- a/src/dusk/imgui/ImGuiEngine.cpp
+++ b/src/dusk/imgui/ImGuiEngine.cpp
@@ -65,6 +65,7 @@ ImFont* ImGuiEngine::fontExtraLarge;
 ImFont* ImGuiEngine::fontMono;
 ImTextureID ImGuiEngine::orgIcon = 0;
 ImTextureID ImGuiEngine::duskLogo = 0;
+float ImGuiEngine::baseFontScale = 1.0f;
 
 inline ImFont* CreateFont(float size, const std::string& fontPath, std::string_view fontName) {
     bool fontFileExists = !fontPath.empty() && AssetExists(fontPath);
@@ -94,7 +95,8 @@ void ImGuiEngine_Initialize(float scale) {
     ImGui::GetCurrentContext();
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->Clear();
-    io.FontGlobalScale = scale > 0.0f ? 1.0f / scale : 1.0f;
+    ImGuiEngine::baseFontScale = scale > 0.0f ? 1.0f / scale : 1.0f;
+    io.FontGlobalScale = ImGuiEngine::baseFontScale;
     io.ConfigWindowsMoveFromTitleBarOnly = IsMobile;
 
     ImGuiEngine::fontNormal =

--- a/src/dusk/imgui/ImGuiEngine.hpp
+++ b/src/dusk/imgui/ImGuiEngine.hpp
@@ -13,6 +13,11 @@ public:
     static ImFont* fontMono;
     static ImTextureID orgIcon;
     static ImTextureID duskLogo;
+    // DPI-derived font scale baked at init time by ImGuiEngine_Initialize(), before the user's
+    // Debug UI Scale preference is applied. Multiply this by that preference every frame to get
+    // io.FontGlobalScale, rather than overwriting FontGlobalScale directly (which would require a
+    // full re-init/font atlas rebake any time the preference changes).
+    static float baseFontScale;
 };
 
 void ImGuiEngine_Initialize(float scale);

--- a/src/dusk/logging.cpp
+++ b/src/dusk/logging.cpp
@@ -334,6 +334,7 @@ void aurora_log_callback(AuroraLogLevel level, const char* module, const char* m
 
 
 aurora::Module DuskLog("dusk");
+aurora::Module ApItemLog("ap_items");
 
 void dusk::InitializeFileLogging(const std::filesystem::path& configDir, AuroraLogLevel logLevel) {
     if (!g_logStateAlive.load(std::memory_order_acquire)) {

--- a/src/dusk/randomizer/game/randomizer_context.cpp
+++ b/src/dusk/randomizer/game/randomizer_context.cpp
@@ -44,6 +44,10 @@ std::optional<std::string> RandomizerContext::WriteToFile(const fspath& path) {
     // as single characters and not numbers
 
     out["mStartEventFlags"] = this->mStartEventFlags;
+
+    const std::list<u64> processedNetworkItems(this->mProcessedNetworkItems.begin(), this->mProcessedNetworkItems.end());
+    out["mProcessedNetworkItems"] = processedNetworkItems;
+
     for (const auto& [region, flags] : this->mStartRegionFlags) {
         const std::list<u16> u16Flags(flags.begin(), flags.end());
         out["mStartRegionFlags"][static_cast<u16>(region)] = u16Flags;
@@ -161,6 +165,11 @@ std::optional<std::string> RandomizerContext::LoadFromPath(const fspath& path) {
     // Event flags
     for (const auto& flag : in["mStartEventFlags"]) {
         this->mStartEventFlags.push_back(flag.as<u16>());
+    }
+
+    // Already-processed items received from other players (see field comment in the header)
+    for (const auto& keyNode : in["mProcessedNetworkItems"]) {
+        this->mProcessedNetworkItems.insert(keyNode.as<u64>());
     }
     // Region Flags
     for (const auto& regionNode : in["mStartRegionFlags"]) {
@@ -372,9 +381,7 @@ int RandomizerState::_create() {
     mEventItemStatus = QUEUE_EMPTY;
     mHasPendingToDChange = false;
     // g_customMenuRing._initialize();
-    for (int i = 0; i < EVENT_ITEM_QUEUE_SIZE; i++) {
-        mEventItemQueue[i] = 0;
-    }
+    mEventItemQueue.clear();
     return 1;
 }
 
@@ -628,18 +635,35 @@ void RandomizerState::handlePoeItem(u8 bitSw)
 
 void RandomizerState::addItemToEventQueue(u8 item)
 {
-    for (int i = 0; i < EVENT_ITEM_QUEUE_SIZE; i++)
-    {
-        if (mEventItemQueue[i] == 0)
-        {
-            mEventItemQueue[i] = item;
-            break;
-        }
-    }
+    mEventItemQueue.push_back(item);
+    ApItemLog.info("queue: stored item {} (queue size now {})", item, mEventItemQueue.size());
 }
 
 void RandomizerState::initGiveItemToPlayer()
 {
+    // Pop a completed item off the queue unconditionally, before the mProcID switch below. The
+    // get-item cutscene itself puts Link into PROC_GET_ITEM, which is deliberately NOT one of the
+    // "safe" states that switch matches (so a new item can't be triggered mid-cutscene). But the
+    // pop-the-finished-item step was previously nested inside that same switch, so once a cutscene
+    // set CLEAR_QUEUE, there was no way to ever act on it: Link is sitting in exactly the one state
+    // the switch excludes. That permanently deadlocked the queue - the first item played its
+    // cutscene fine, and every item after it (this session and all future ones) was stuck forever.
+    if (getGiveItemToPlayerStatus() == CLEAR_QUEUE) {
+        if (!mEventItemQueue.empty()) {
+            ApItemLog.info("drain: clearing completed queue item {} (queue size now {})",
+                mEventItemQueue.front(), mEventItemQueue.size() - 1);
+            mEventItemQueue.pop_front();
+        }
+        setGiveItemToPlayerStatus(QUEUE_EMPTY);
+    }
+
+    const bool hasPendingItem = !mEventItemQueue.empty();
+    if (hasPendingItem || getGiveItemToPlayerStatus() != QUEUE_EMPTY) {
+        // Only fires while something is actually pending, so this can't flood the log on its own.
+        ApItemLog.info("drain: status={} link mProcID={}",
+            getGiveItemToPlayerStatus(), daAlink_getAlinkActorClass()->mProcID);
+    }
+
     switch (daAlink_getAlinkActorClass()->mProcID)
     {
         case daAlink_c::PROC_WAIT:
@@ -654,42 +678,34 @@ void RandomizerState::initGiveItemToPlayer()
             // Check if link is currently in a cutscene
             if (daAlink_getAlinkActorClass()->checkEventRun())
             {
+                if (hasPendingItem) {
+                    ApItemLog.info("drain: blocked, checkEventRun() is true");
+                }
                 break;
             }
 
             // Ensure that link is not currently in a message-based event.
             if (daAlink_getAlinkActorClass()->getEventId() != 0)
             {
+                if (hasPendingItem) {
+                    ApItemLog.info("drain: blocked, getEventId()={} (nonzero)",
+                        daAlink_getAlinkActorClass()->getEventId());
+                }
                 break;
             }
 
+            // Note: giveItemToPlayerStatus can't be CLEAR_QUEUE here - that's already handled
+            // unconditionally above, before this switch, and reset to QUEUE_EMPTY.
             u8 itemToGive = 0xFF;
 
-            for (int i = 0; i < EVENT_ITEM_QUEUE_SIZE; i++)
+            if (!mEventItemQueue.empty())
             {
-                const u8 storedItem = mEventItemQueue[i];
-
-                if (storedItem)
+                if (getGiveItemToPlayerStatus() == QUEUE_EMPTY)
                 {
-                    const u8 giveItemToPlayerStatus = getGiveItemToPlayerStatus();
-
-                    // If we have the call to clear the queue, then we want to clear the item and break out.
-                    if (giveItemToPlayerStatus == CLEAR_QUEUE)
-                    {
-                        mEventItemQueue[i] = 0;
-                        setGiveItemToPlayerStatus(QUEUE_EMPTY);
-                        break;
-                    }
-
-                    // If the queue is empty and we have an item to give, update the queue state.
-                    else if (giveItemToPlayerStatus == QUEUE_EMPTY)
-                    {
-                        setGiveItemToPlayerStatus(ITEM_IN_QUEUE);
-                    }
-
-                    itemToGive = verifyProgressiveItem(storedItem);
-                    break;
+                    setGiveItemToPlayerStatus(ITEM_IN_QUEUE);
                 }
+
+                itemToGive = verifyProgressiveItem(mEventItemQueue.front());
             }
 
             // if there is no item to give, break out of the case.
@@ -697,6 +713,8 @@ void RandomizerState::initGiveItemToPlayer()
             {
                 break;
             }
+
+            ApItemLog.info("drain: triggering get-item cutscene for verified item {}", itemToGive);
 
             g_dComIfG_gameInfo.play.getEvent()->setGtItm(itemToGive);
 
@@ -1052,6 +1070,13 @@ RandomizerContext WriteSeedData(randomizer::logic::world::World* world) {
         }
 
         const auto& metaData = location->GetMetadata();
+
+        // The 10 categories checked in this block (Chest, Poe, Freestanding Item, Bug Reward,
+        // Sky Character, Golden Wolf, Twilit Insect, Name Lookup, FLW Message, Shop) are exactly
+        // RandomizerContext::kAtomicallyGrantedLocationCategories - ArchipelagoContext::
+        // hasAtomicLocalGrant() depends on that same list to decide which locations grant their
+        // item atomically/locally. Adding a category here without adding it to that shared list
+        // (or vice versa) will silently misclassify the new category's dedup behavior.
 
         // Chest Overrides
         // Keyed by u16 of 0xFF00 (stage index) and 0x00FF (tbox id)

--- a/src/dusk/randomizer/game/randomizer_context.cpp
+++ b/src/dusk/randomizer/game/randomizer_context.cpp
@@ -581,6 +581,25 @@ static void updateGoalFlags() {
             dComIfGs_onEventBit(FIXED_THE_MIRROR_OF_TWILIGHT);
         }
     }
+
+    // Re-derive the Goron Mines elder ladder switches from the "talked to elder" event bits;
+    // the randomizer's key-shard shortcut skips the dialogue that vanilla uses to set them.
+    {
+        constexpr int GM_SAVE_ID       = 0x11;  // D_MN04
+        constexpr int GM_SW_ELDER_LAD1 = 0x27;
+        constexpr int GM_SW_ELDER_LAD2 = 0x28;
+
+        if (dComIfGs_isEventBit(TALKED_TO_GOR_AMATO_IN_GORON_MINES) ||
+            dComIfGs_isEventBit(TALKED_TO_GOR_EBIZO_IN_GORON_MINES) ||
+            dComIfGs_isEventBit(TALKED_TO_GOR_LIGGS_IN_GORON_MINES)) {
+            if (!dComIfGs_isStageSwitch(GM_SAVE_ID, GM_SW_ELDER_LAD1)) {
+                dComIfGs_onStageSwitch(GM_SAVE_ID, GM_SW_ELDER_LAD1);
+            }
+            if (!dComIfGs_isStageSwitch(GM_SAVE_ID, GM_SW_ELDER_LAD2)) {
+                dComIfGs_onStageSwitch(GM_SAVE_ID, GM_SW_ELDER_LAD2);
+            }
+        }
+    }
 }
 
 int RandomizerState::execute() {
@@ -1071,12 +1090,10 @@ RandomizerContext WriteSeedData(randomizer::logic::world::World* world) {
 
         const auto& metaData = location->GetMetadata();
 
-        // The 10 categories checked in this block (Chest, Poe, Freestanding Item, Bug Reward,
-        // Sky Character, Golden Wolf, Twilit Insect, Name Lookup, FLW Message, Shop) are exactly
-        // RandomizerContext::kAtomicallyGrantedLocationCategories - ArchipelagoContext::
-        // hasAtomicLocalGrant() depends on that same list to decide which locations grant their
-        // item atomically/locally. Adding a category here without adding it to that shared list
-        // (or vice versa) will silently misclassify the new category's dedup behavior.
+        // Populates the per-category override tables below. Categories that also grant their item
+        // locally must be listed in RandomizerContext::kAtomicallyGrantedLocationCategories, which
+        // hasAtomicLocalGrant() uses for dedup. "Twilit Insect" and "Bug Reward" are intentionally
+        // not in that list: their tables are tracker-only and their item comes from the network.
 
         // Chest Overrides
         // Keyed by u16 of 0xFF00 (stage index) and 0x00FF (tbox id)

--- a/src/dusk/randomizer/game/randomizer_context.hpp
+++ b/src/dusk/randomizer/game/randomizer_context.hpp
@@ -4,6 +4,7 @@
 #include <dolphin/types.h>
 
 #include <array>
+#include <deque>
 #include <list>
 #include <iomanip>
 #include <optional>
@@ -25,6 +26,22 @@ public:
     static constexpr size_t OBJ_DELETE_SIZE = 1;
     static constexpr u8 ROOM_STAGE = 0xFF;
 
+    // Location categories whose randomized item gets embedded directly into a local object/NPC/
+    // dialogue lookup (mTreasureChestOverrides, mPoeOverrides, mFreestandingItemOverrides,
+    // mBugRewardOverrides, mSkyCharacterOverrides, mGoldenWolfOverrides, mTwilitInsectOverrides,
+    // mItemLocations, mFlowItemMessageOverrides, mShopOverrides) and granted the instant the player
+    // physically interacts with it, atomically with the location's checked-state - see each
+    // `location->HasCategories(...)` block in randomizer_context.cpp's world-gen loop (~line 1076
+    // onward) for the per-category override-table population, and
+    // ArchipelagoContext::hasAtomicLocalGrant() (archipelago_context.cpp) for the dedup logic that
+    // depends on this same category set. Both sides must reference this single list - a category
+    // added to one without the other already caused one real bug (Iza's Helping Hand double-granting
+    // a Poe Soul when "Name Lookup" was initially missing from the dedup side).
+    static constexpr std::array kAtomicallyGrantedLocationCategories = {
+        "Chest", "Poe", "Freestanding Item", "Bug Reward", "Sky Character", "Golden Wolf",
+        "Twilit Insect", "Name Lookup", "FLW Message", "Shop"
+    };
+
     RandomizerContext() = default;
 
     bool mCreatingSave{false};
@@ -37,6 +54,14 @@ public:
     std::list<u16> mStartEventFlags{};
     std::unordered_map<u8, std::list<u8>> mStartRegionFlags{};
     std::list<u8> mStartingInventory{};
+
+    // Tracks (player, location) pairs for items already received from OTHER players, so a resync
+    // on reconnect doesn't re-grant them. AP location IDs are shared globally across all players of
+    // the same game (not per-player), so a plain location-id check can't distinguish "my location"
+    // from "the same-numbered location in someone else's world" - this explicit record is necessary
+    // because IsLocationChecked() only reflects this player's own location-collected state, which is
+    // meaningless for items found by someone else. Encoded as (player << 48) | (location & 0xFFFFFFFFFFFF).
+    std::unordered_set<u64> mProcessedNetworkItems{};
 
     struct itemLocationData{
         int itemId{0xFF};
@@ -85,6 +110,11 @@ public:
     std::optional<std::string> LoadFromHash(const std::string& hash);
     std::optional<std::string> LoadFromPath(const fspath& path);
     std::filesystem::path GetSeedDataPath() const;
+
+    static u64 EncodeNetworkItemKey(int player, int64_t location) {
+        return (static_cast<u64>(static_cast<u32>(player)) << 48) |
+               (static_cast<u64>(location) & 0xFFFFFFFFFFFFULL);
+    }
 
     enum Settings {
         HYRULE_BARRIER_REQUIREMENTS,
@@ -149,8 +179,6 @@ public:
         CLEAR_QUEUE,
     };
 
-    static constexpr u8 EVENT_ITEM_QUEUE_SIZE = 10;
-
     RandomizerState() {mInitialized = false;}
 
     int _create();
@@ -181,7 +209,9 @@ public:
     u8 mEventItemStatus{};
     bool mHasPendingToDChange{false};
     u8 mTimeChange{};
-    u8 mEventItemQueue[EVENT_ITEM_QUEUE_SIZE];
+    // Unbounded FIFO of items waiting for the get-item cutscene. Was previously a fixed-size array
+    // that silently dropped items once full during a large multiworld sync burst.
+    std::deque<u8> mEventItemQueue;
     bool mRoomReloadingState{false};
 
     // Used to store an item id for a flow message override so that we can give the item

--- a/src/dusk/randomizer/game/randomizer_context.hpp
+++ b/src/dusk/randomizer/game/randomizer_context.hpp
@@ -26,20 +26,15 @@ public:
     static constexpr size_t OBJ_DELETE_SIZE = 1;
     static constexpr u8 ROOM_STAGE = 0xFF;
 
-    // Location categories whose randomized item gets embedded directly into a local object/NPC/
-    // dialogue lookup (mTreasureChestOverrides, mPoeOverrides, mFreestandingItemOverrides,
-    // mBugRewardOverrides, mSkyCharacterOverrides, mGoldenWolfOverrides, mTwilitInsectOverrides,
-    // mItemLocations, mFlowItemMessageOverrides, mShopOverrides) and granted the instant the player
-    // physically interacts with it, atomically with the location's checked-state - see each
-    // `location->HasCategories(...)` block in randomizer_context.cpp's world-gen loop (~line 1076
-    // onward) for the per-category override-table population, and
-    // ArchipelagoContext::hasAtomicLocalGrant() (archipelago_context.cpp) for the dedup logic that
-    // depends on this same category set. Both sides must reference this single list - a category
-    // added to one without the other already caused one real bug (Iza's Helping Hand double-granting
-    // a Poe Soul when "Name Lookup" was initially missing from the dedup side).
+    // Location categories whose randomized item is embedded into a local object/NPC/dialogue lookup
+    // and granted atomically when the player interacts with it. hasAtomicLocalGrant() (in
+    // archipelago_context.cpp) reads this same list for dedup, so both sides must stay in sync.
+    // "Twilit Insect" and "Bug Reward" are intentionally excluded: nothing in actor code grants
+    // from their tables, so their item only arrives via the network. Listing them here would let
+    // dedup discard that only source. Their override tables stay populated for the tracker's getLocationItem().
     static constexpr std::array kAtomicallyGrantedLocationCategories = {
-        "Chest", "Poe", "Freestanding Item", "Bug Reward", "Sky Character", "Golden Wolf",
-        "Twilit Insect", "Name Lookup", "FLW Message", "Shop"
+        "Chest", "Poe", "Freestanding Item", "Sky Character", "Golden Wolf",
+        "Name Lookup", "FLW Message", "Shop"
     };
 
     RandomizerContext() = default;

--- a/src/dusk/settings.cpp
+++ b/src/dusk/settings.cpp
@@ -55,6 +55,7 @@ UserSettings g_userSettings = {
         .enableMirrorMode {"game.enableMirrorMode", false},
         .minimalHUD {"game.minimalHUD", false},
         .hudScale {"game.hudScale", 1.0f},
+        .debugUIScale {"game.debugUIScale", 1.0f},
         .pauseOnFocusLost {"game.pauseOnFocusLost", false},
         .enableLinkDollRotation {"game.enableLinkDollRotation", false},
         .enableAchievementToasts {"game.enableAchievementToasts", true},
@@ -313,6 +314,7 @@ void registerSettings() {
     Register(g_userSettings.game.touchCameraYSensitivity);
     Register(g_userSettings.game.minimalHUD);
     Register(g_userSettings.game.hudScale);
+    Register(g_userSettings.game.debugUIScale);
     Register(g_userSettings.game.pauseOnFocusLost);
     Register(g_userSettings.game.enableDiscordPresence);
     Register(g_userSettings.game.bloomMode);

--- a/src/dusk/ui/archi_connect_modal.cpp
+++ b/src/dusk/ui/archi_connect_modal.cpp
@@ -1,8 +1,10 @@
 #include <dusk/ui/archi_connect_modal.hpp>
 #include <dusk/ui/string_button.hpp>
 
+#include <chrono>
 #include <thread>
 #include "dusk/archipelago/archipelago_context.hpp"
+#include "dusk/logging.h"
 #include "m_Do/m_Do_audio.h"
 
 namespace dusk::ui {
@@ -87,8 +89,43 @@ void HandleArchipelagoConnect() {
 
     connectStatus.store(ArchiConnectModal::ConnectionStatus::Generating);
 
-    while (!archi::ArchipelagoContext::IsReceivedLocationScouts()) {
-        std::this_thread::yield();
+    // Location scouts are requested once by the AP message thread right after connecting. That
+    // request/response can occasionally get delayed or lost (e.g. while the connection is also
+    // being flooded with a large backlog of item messages on reconnect), and there was previously
+    // no timeout here at all - a lost response meant this spun forever, burning a CPU core and
+    // leaving the player stuck on "Loading seed data into game..." with no way out but a force-close.
+    constexpr auto kScoutTimeout = std::chrono::seconds(15);
+    constexpr int kMaxScoutAttempts = 3;
+    bool receivedScouts = false;
+
+    for (int attempt = 1; attempt <= kMaxScoutAttempts && !receivedScouts; attempt++) {
+        if (attempt > 1) {
+            DuskLog.warn("Location scouts not received after {}s, retrying (attempt {}/{})",
+                kScoutTimeout.count(), attempt, kMaxScoutAttempts);
+            archi::ArchipelagoContext::RequestAllLocationScout();
+        }
+
+        const auto waitStart = std::chrono::steady_clock::now();
+        while (!archi::ArchipelagoContext::IsReceivedLocationScouts()) {
+            if (!archi::ArchipelagoContext::IsConnected()) {
+                DuskLog.error("Lost connection while waiting for location scouts.");
+                connectStatus.store(ArchiConnectModal::ConnectionStatus::Error);
+                return;
+            }
+            if (std::chrono::steady_clock::now() - waitStart > kScoutTimeout) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+
+        receivedScouts = archi::ArchipelagoContext::IsReceivedLocationScouts();
+    }
+
+    if (!receivedScouts) {
+        DuskLog.error("Failed to receive location scouts after {} attempts, giving up.", kMaxScoutAttempts);
+        archi::ArchipelagoContext::DisconnectFromServer();
+        connectStatus.store(ArchiConnectModal::ConnectionStatus::Error);
+        return;
     }
 
     archi::ArchipelagoContext::GenerateLocalWorldData();

--- a/src/dusk/ui/archi_connect_modal.cpp
+++ b/src/dusk/ui/archi_connect_modal.cpp
@@ -128,6 +128,26 @@ void HandleArchipelagoConnect() {
         return;
     }
 
+    // seed_name arrives asynchronously after connect; GenerateLocalWorldData() needs it to
+    // resolve the seed folder, so wait for it (with a timeout) before continuing.
+    constexpr auto kRoomInfoTimeout = std::chrono::seconds(5);
+    const auto roomInfoWaitStart = std::chrono::steady_clock::now();
+
+    while (!archi::ArchipelagoContext::IsRoomInfoReady()) {
+        if (!archi::ArchipelagoContext::IsConnected()) {
+            DuskLog.error("Lost connection while waiting for room info.");
+            connectStatus.store(ArchiConnectModal::ConnectionStatus::Error);
+            return;
+        }
+        if (std::chrono::steady_clock::now() - roomInfoWaitStart > kRoomInfoTimeout) {
+            DuskLog.error("Room info (seed name) not received after {}s, giving up.", kRoomInfoTimeout.count());
+            archi::ArchipelagoContext::DisconnectFromServer();
+            connectStatus.store(ArchiConnectModal::ConnectionStatus::Error);
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
     archi::ArchipelagoContext::GenerateLocalWorldData();
 
     connectStatus.store(ArchiConnectModal::ConnectionStatus::Success);

--- a/src/dusk/ui/settings.cpp
+++ b/src/dusk/ui/settings.cpp
@@ -1582,6 +1582,11 @@ SettingsWindow::SettingsWindow(bool prelaunch) : mPrelaunch(prelaunch) {
                     },
                 .isDisabled = [] { return getSettings().game.speedrunMode; },
             });
+        config_percent_select(leftPane, rightPane, getSettings().game.debugUIScale,
+            "Debug UI Scale",
+            "Scales the size of the Shift+F1 debug console, including the Rando Tracker window.",
+            50, 200, 5,
+            [] { return !getSettings().backend.enableAdvancedSettings.getValue(); });
         config_bool_select(leftPane, rightPane, getSettings().game.showInputViewer,
             {
                 .key = "Show Input Viewer",


### PR DESCRIPTION
## Summary

Fixed the following issues:
- crashing when retrieving settings from the  AP server causing it to  use  the default settings.
- item duping (small keys, sky characters, poe souls etc.)
- items not being retrieven during a big batch  (async AP run, more than 10 items received since last play)
- Certain flags not being set (goron elders in  the mines, Iza minigame when you don't teleport up there)
- Preventing items beinig send/obtained twice (ie progressive sword on heart container, poe soul on Iza helping hand)
- Added a timeout to the connection on the save file menu. If AP doesn't respond, you don't get stuck
- Save file losing AP link if autosave overwrites it with an empty string due  to connection issues or accidentally cancelling the connection on the save file screen.


I've run through it several times in a solo AP with DS3 as my second game.. Last 2 runs went flawless.