### PR TITLE
Fix interpretation of `needed` in audio callback

### DIFF
--- a/src/dusk/audio/DuskAudioSystem.cpp
+++ b/src/dusk/audio/DuskAudioSystem.cpp
@@ -35,7 +35,7 @@ static void SDLCALL GetNewAudio(
 /**
  * Render an entire new frame of audio and output it to SDL3.
  * Note: "audio frames" are unrelated to video frames.
- * @return Amount of audio samples rendered.
+ * @return Amount of audio samples rendered in bytes.
  */
 static int RenderNewAudioFrame();
 
@@ -121,7 +121,7 @@ int RenderNewAudioFrame() {
         JASAudioThread::snIntCount -= 1;
     }
 
-    return static_cast<u16>(countSubframes) * DSP_SUBFRAME_SIZE;
+    return static_cast<u16>(countSubframes) * sizeof(OutputSubframe);
 }
 
 static void InterleaveOutputData(const OutputSubframe& data, std::span<f32> target) {


### PR DESCRIPTION
The `needed` parameter in the `GetNewAudio` callback was incorrectly interpreted as a number of samples rather than a number of bytes. This caused `RenderNewAudioFrame` to be called far more than necessary, along with some audible bugs (Wolf Link howling pitch).

Howling before:
<img width="1280" height="960" alt="mpv-shot0004" src="https://github.com/user-attachments/assets/40bfdd63-e3b2-4d72-b65f-9696fc911ad6" />

Howling after (not completely fixed but much better):
<img width="1280" height="960" alt="mpv-shot0009" src="https://github.com/user-attachments/assets/b5a4fac5-3bb5-4a2a-a97e-1c94463fad30" />

