### PR TITLE
Generate mipmaps for mod menu images

### DIFF
--- a/src/dusk/ui/mod_texture_provider.cpp
+++ b/src/dusk/ui/mod_texture_provider.cpp
@@ -182,6 +182,7 @@ std::optional<aurora::rmlui::RuntimeTexture> mod_texture_provider(std::string_vi
         .rgba8 =
             std::span{reinterpret_cast<const std::byte*>(image.pixels.data()), image.pixels.size()},
         .premultipliedAlpha = true,
+        .generateMipmaps = true,
     };
 }
 


### PR DESCRIPTION
Requires https://github.com/encounter/aurora/pull/245

<img width="343" height="130" alt="dusklight_lmC8E07wWd" src="https://github.com/user-attachments/assets/59230f8f-d6ff-4ee5-b85e-f93b5236fea3" />
<img width="326" height="118" alt="dusklight_QpY1YrNAp9" src="https://github.com/user-attachments/assets/0b26f1e9-0a66-491a-be76-63142cd496dd" />
