### PR TITLE
SaveService: Move save_slot_written call and onWritten notification

### DIFF
--- a/src/d/d_menu_save.cpp
+++ b/src/d/d_menu_save.cpp
@@ -1441,9 +1441,6 @@ void dMenu_save_c::dataWrite() {
     }
 
     dataSave();
-#if TARGET_PC
-    dusk::mods::svc::save_slot_written(mSelectedFile, mSaveBuffer + mSelectedFile * QUEST_LOG_SIZE);
-#endif
 }
 
 void dMenu_save_c::memCardDataSaveWait() {
@@ -1455,6 +1452,12 @@ void dMenu_save_c::memCardDataSaveWait() {
 
     mCmdState = g_mDoMemCd_control.SaveSync();
     if (mCmdState != 0) {
+#if TARGET_PC
+        if (mCmdState == 1) {
+                dusk::mods::svc::save_slot_written(
+                    mSelectedFile, mSaveBuffer + mSelectedFile * QUEST_LOG_SIZE);
+            }
+#endif
         printf("save cmdState %d\n", mCmdState);
         mMenuProc = PROC_MEMCARD_DATA_SAVE_WAIT2;
     }

--- a/src/d/d_menu_save.cpp
+++ b/src/d/d_menu_save.cpp
@@ -1441,6 +1441,9 @@ void dMenu_save_c::dataWrite() {
     }
 
     dataSave();
+#if TARGET_PC
+    dusk::mods::svc::save_slot_written(mSelectedFile, mSaveBuffer + mSelectedFile * QUEST_LOG_SIZE);
+#endif
 }
 
 void dMenu_save_c::memCardDataSaveWait() {
@@ -1468,10 +1471,6 @@ void dMenu_save_c::memCardDataSaveWait2() {
         mDoAud_seStart(Z2SE_SY_FILE_SAVE_OK, NULL, 0, 0);
         dComIfGs_setDataNum(mSelectedFile);
         dComIfGs_setNoFile(0);
-
-#if TARGET_PC
-        dusk::mods::svc::save_slot_written(mSelectedFile, mSaveBuffer + mSelectedFile * QUEST_LOG_SIZE);
-#endif
 
         if (mUseType == TYPE_WHITE_EVENT || mUseType == TYPE_BLACK_EVENT) {
             headerTxtSet(0x530);  // Saved.

--- a/src/dusk/mods/svc/save.cpp
+++ b/src/dusk/mods/svc/save.cpp
@@ -193,6 +193,8 @@ void save_slot_written(uint32_t slot, const void* slotData) {
     if (slot >= kSlotCount) {
         return;
     }
+    s_currentSlot = static_cast<int32_t>(slot);
+    notify(slot, &SaveObserverRecord::onWritten, "save-written");
     load_sidecar();
     auto& store = s_slots[slot];
     if (slotData != nullptr) {
@@ -200,8 +202,6 @@ void save_slot_written(uint32_t slot, const void* slotData) {
         store.snapshotCrc = utils::crc32(slotData, kQuestLogSize);
     }
     flush_sidecar();
-    s_currentSlot = static_cast<int32_t>(slot);
-    notify(slot, &SaveObserverRecord::onWritten, "save-written");
 }
 
 void save_slot_copied(uint32_t fromSlot, uint32_t toSlot) {


### PR DESCRIPTION
- `save_slot_written` was being called in `memCardDataSaveWait2()` which doesn't run until the full saving animation has finished. This was fine if instant saves were on, but if instant saves were off then it was possible to soft reset during the saving animation and completely skip the call to `save_slot_written` while still saving the regular file data to the memory card. `save_slot_written` has been moved to the end of `dataWrite` so that it runs immediately after save file data is set to the memory card. 

- Inside `save_slot_written`, notifying the observers was done after flushing the sidecar, meaning that any attempts at saving data in a registered `onWritten` function to the sidecar wouldn't get picked up until the next time save data was written. Notifying the observers has been moved to before flushing the sidecar so that data saved in `onWritten` functions gets flushed too.