### PR TITLE
Revert change to J3DMaterial::needsInterpCallBack()

### DIFF
--- a/libs/JSystem/src/J3DGraphBase/J3DMaterial.cpp
+++ b/libs/JSystem/src/J3DGraphBase/J3DMaterial.cpp
@@ -373,10 +373,6 @@ s32 J3DMaterial::newSingleSharedDisplayList(u32 dlSize) {
 
 #if TARGET_PC
 bool J3DMaterial::needsInterpCallBack() const {
-    if (mMaterialAnm != NULL) {
-        return true;
-    }
-
     for (int i = 0, n = getTexGenNum(); i < n; i++) {
         J3DTexMtx* pTexMtx = mTexGenBlock->getTexMtx(i);
         if (pTexMtx != NULL) {


### PR DESCRIPTION
Revert a portion of d6787118 which mysteriously works on my system, but causes objects (known example: randomizer treasure chest in Link's house) to turn black in Dusklight's GH Actions builds.

Current belief is that this points to a much deeper problem in our interpolation solution, but until a refactor can be worked out for that, just revert what's breaking the camel's back.