### PR TITLE
Basic .editorconfig demanding whitespace rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{c,cpp,h,hpp,cmake}]
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
insert final newline/trim trailing whitespace only.

I was initially hesitant to do this because it'd really need to be upstreamed to decomp for consistency, but eh?