### PR TITLE
Shutdown audio system upon exit

### DIFF
--- a/src/dusk/audio/DuskAudioSystem.cpp
+++ b/src/dusk/audio/DuskAudioSystem.cpp
@@ -107,7 +107,8 @@ void dusk::audio::Initialize() {
 }
 
 void dusk::audio::Reinitialize() {
-    if (InitSDL3Output()) {
+    // don't re-init unless we've initialized first (using PlaybackStream being set as proxy)
+    if (PlaybackStream && InitSDL3Output()) {
         SDL_ResumeAudioStreamDevice(PlaybackStream);
     }
 }

--- a/src/dusk/audio/DuskAudioSystem.cpp
+++ b/src/dusk/audio/DuskAudioSystem.cpp
@@ -112,6 +112,15 @@ void dusk::audio::Reinitialize() {
     }
 }
 
+void dusk::audio::Shutdown() {
+    if (PlaybackStream) {
+        SDL_DestroyAudioStream(PlaybackStream);
+        PlaybackStream = nullptr;
+    }
+
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+}
+
 void dusk::audio::SetMasterVolume(const f32 value) {
     JASCriticalSection section;
 

--- a/src/dusk/audio/DuskAudioSystem.h
+++ b/src/dusk/audio/DuskAudioSystem.h
@@ -21,6 +21,8 @@ namespace dusk::audio {
 
     void Reinitialize();
 
+    void Shutdown();
+
     void SetEnableReverb(bool value);
 
     void SetMasterVolume(f32 value);

--- a/src/m_Do/m_Do_main.cpp
+++ b/src/m_Do/m_Do_main.cpp
@@ -975,6 +975,7 @@ int game_main(int argc, char* argv[]) {
 #if BOREALIS_HAS_DISCORD
     dusk::discord::shutdown();
 #endif
+    dusk::audio::Shutdown();
     dusk::ui::shutdown();
     dusk::texture_replacements::shutdown();
     dusk::config::shutdown();


### PR DESCRIPTION
The audio thread reads the `audio.outputMode` config var during the render callback, which causes an abort when the config var is unregistered during exit. This adds a shutdown function to the audio system that is called before config shutdown.