### PR TITLE
Fix minimap pulsing effect

### DIFF
--- a/src/d/d_meter_map.cpp
+++ b/src/d/d_meter_map.cpp
@@ -17,6 +17,7 @@
 #include "m_Do/m_Do_controller_pad.h"
 #include "d/d_camera.h"
 #if TARGET_PC
+#include "JSystem/JUtility/JUTPalette.h"
 #include "dusk/settings.h"
 #include <algorithm>
 #endif
@@ -644,6 +645,11 @@ void dMeterMap_c::draw() {
         mMapJ2DPicture->setAlpha(alpha);
 
         #if TARGET_PC
+        // Ensure minimap palette gets reuploaded since it is modified for the pulsating border
+        // effect.
+        JUTPalette* pPalette = mMapJ2DPicture->getTexture(0)->getPalette();
+        pPalette->dataUploaded();
+
         // Scale the minimap with the user HUD scale and shift down so its bottom-left
         // corner stays anchored to the same screen position as at scale 1.0.
         const f32 userHudScale = dGetUserHudScale();


### PR DESCRIPTION
Currently the updates to the minimap used for the pulsating border effect (used for wagon escort and Shadow Beast encounters among others) are being ignored since it is cached. This PR forces the palette to be reuploaded each time the minimap is drawn so it is not stale.

## Before

https://github.com/user-attachments/assets/5010abfa-6f14-489a-a50d-973ada8f624f

## After

https://github.com/user-attachments/assets/c7bd6af4-fb32-492c-8a94-d9208243da8d