### PR TITLE
Fix GraphicsTuner arrows after mod browser PR

### DIFF
--- a/src/dusk/ui/graphics_tuner.cpp
+++ b/src/dusk/ui/graphics_tuner.cpp
@@ -126,12 +126,11 @@ Rml::Element* create_stepped_carousel_root(Rml::Element* parent) {
 
 Rml::Element* create_stepped_carousel_arrow(
     Rml::Element* parent, const Rml::String& className, const Rml::String& label) {
-    auto* doc = parent->GetOwnerDocument();
-    auto button = doc->CreateElement("button");
+    auto* button = append(parent, "button");
     button->SetClass("stepped-carousel-arrow", true);
     button->SetClass(className, true);
-    append_text(button.get(), label);
-    return parent->AppendChild(std::move(button));
+    append_text(button, label);
+    return button;
 }
 
 void update_carousel_arrow_color(Rml::Element* arrow, bool dim) {


### PR DESCRIPTION
Mod browser PR updated tons of elements to use `append_text`, but this silently skips buttons that are not yet attached to a document, causing GraphicsTuner's carousel arrows to become invisible. The button is now immediately appended to resolve that, matching the behavior of the rest of the UI.